### PR TITLE
Repair hypothesis strategies for interpolation and clean up clutter in tests

### DIFF
--- a/PyDynamic/uncertainty/interpolation.py
+++ b/PyDynamic/uncertainty/interpolation.py
@@ -63,7 +63,7 @@ def interp1d_unc(
     if not np.all(t[1:] >= t[:-1]):
         raise ValueError("Array of timestamps needs to be in ascending order.")
     # Check for proper dimensions of inputs.
-    if ((min(t) > t_new) | (max(t) < t_new)).any():
+    if ((t.min() > t_new) | (t.max() < t_new)).any():
         raise ValueError(
             "Array of interpolation timestamps must be in the range of original "
             "timestamps."

--- a/PyDynamic/uncertainty/interpolation.py
+++ b/PyDynamic/uncertainty/interpolation.py
@@ -27,7 +27,7 @@ def interp1d_unc(
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Interpolate arbitrary time series considering the associated uncertainties
 
-    The interpolation time stamps must lie within the range of the original
+    The interpolation timestamps must lie within the range of the original
     timestamps. In addition, at least two of each of the original timestamps,
     measured values and associated measurement uncertainties are required and an
     equal number of each of these three.
@@ -86,18 +86,22 @@ def interp1d_unc(
         interp_uy = interp1d(t, uy, kind=kind)
         uy_new = interp_uy(t_new)
     elif kind == "linear":
-        # Determine the relevant interpolation intervals for all new timestamps.
-        # We determine the intervals for each timestamp in t_new by finding the
-        # biggest of all timestamps in t smaller or equal than the one in t_new.
-        # If the maximums are equal we manually choose the last two
-        # timestamps in t as interval bounds, since our algorithm results in two
-        # times the last timestamp in t.
+        # Determine the relevant interpolation intervals for all interpolation
+        # timestamps. We determine the intervals for each timestamp in t_new by
+        # finding the biggest of all timestamps in t smaller or equal than the one in
+        # t_new. From the array of indices of our left interval bounds we get the
+        # right bounds by just incrementing the indices, which of course
+        # results in index errors at the end of our array, in case the biggest
+        # timestamps in t_new are (quasi) equal to the biggest (i.e. last) timestamp
+        # in t. This gets corrected just after the iteration by simply manually
+        # choosing one interval "further left", which will just at the node result
+        # in the same interpolation (being the actual value of y).
         indices = np.empty_like(t_new, dtype=int)
         it_t_new = np.nditer(t_new, flags=["f_index"])
         while not it_t_new.finished:
             # Find indices of biggest of all timestamps smaller or equal
-            # than current time, assumes that timestamps are in ascending
-            # order.
+            # than current interpolation timestamp. Assume that timestamps are in
+            # ascending order.
             indices[it_t_new.index] = np.where(t <= it_t_new[0])[0][-1]
             it_t_new.iternext()
         # Correct all degenerated intervals. This happens when the last timestamps of

--- a/PyDynamic/uncertainty/interpolation.py
+++ b/PyDynamic/uncertainty/interpolation.py
@@ -100,10 +100,9 @@ def interp1d_unc(
             # order.
             indices[it_t_new.index] = np.where(t <= it_t_new[0])[0][-1]
             it_t_new.iternext()
-        # Correct the last interval in case it degenerated. This happens when the
-        # last timestamps of t and t_new are equal.
-        if indices[-1] == len(t) - 1:
-            indices[-1] -= 1
+        # Correct all degenerated intervals. This happens when the last timestamps of
+        # t and t_new are equal.
+        indices[np.where(indices == len(t) - 1)] -= 1
         t_prev = t[indices]
         t_next = t[indices + 1]
         # Look up corresponding input uncertainties.

--- a/test/test_interpolation.py
+++ b/test/test_interpolation.py
@@ -45,7 +45,7 @@ def timestamps_values_uncertainties_kind(
         dt, kind for interp1d_unc()
     """
     # Set the maximum absolute value for floats to be really unique in calculations.
-    float_abs_max = 1e300
+    float_abs_max = 1e256
     # Set all common parameters for timestamps, measurements values and associated
     # uncertainties.
     shape_for_timestamps = hnp.array_shapes(

--- a/test/test_interpolation.py
+++ b/test/test_interpolation.py
@@ -44,6 +44,8 @@ def timestamps_values_uncertainties_kind(
         A dict containing the randomly generated expected input parameters t, y, uy,
         dt, kind for interp1d_unc()
     """
+    # Set the maximum absolute value for floats to be really unique in calculations.
+    float_abs_max = 1e300
     # Set all common parameters for timestamps, measurements values and associated
     # uncertainties.
     shape_for_timestamps = hnp.array_shapes(
@@ -53,7 +55,10 @@ def timestamps_values_uncertainties_kind(
         "dtype": np.float,
         "shape": shape_for_timestamps,
         "elements": st.floats(
-            min_value=-1e300, max_value=1e300, allow_nan=False, allow_infinity=False
+            min_value=-float_abs_max,
+            max_value=float_abs_max,
+            allow_nan=False,
+            allow_infinity=False,
         ),
         "unique": True,
     }
@@ -81,8 +86,8 @@ def timestamps_values_uncertainties_kind(
 @given(timestamps_values_uncertainties_kind())
 def test_usual_call(interp_inputs):
     # Ensure at least two different timestamps in each series.
-    assume(not (interp_inputs["t"][0] == interp_inputs["t"][-1]))
-    assume(not (interp_inputs["t_new"][0] == interp_inputs["t_new"][-1]))
+    # assume(not (interp_inputs["t"][0] == interp_inputs["t"][-1]))
+    # assume(not (interp_inputs["t_new"][0] == interp_inputs["t_new"][-1]))
 
     t_new, y_new, uy_new = interp1d_unc(**interp_inputs)
     # Check the equal dimensions of the minimum calls output.
@@ -99,8 +104,8 @@ def test_too_few_timestamps_call(interp_inputs):
 @given(timestamps_values_uncertainties_kind())
 def test_wrong_input_length_y_call_interp1d_unc(interp_inputs):
     # Ensure at least two different timestamps in each series.
-    assume(not (interp_inputs["t"][0] == interp_inputs["t"][-1]))
-    assume(not (interp_inputs["t_new"][0] == interp_inputs["t_new"][-1]))
+    # assume(not (interp_inputs["t"][0] == interp_inputs["t"][-1]))
+    # assume(not (interp_inputs["t_new"][0] == interp_inputs["t_new"][-1]))
 
     # Check erroneous calls with unequally long inputs.
     interp_inputs["y"] = np.tile(interp_inputs["y"], 2)
@@ -108,21 +113,8 @@ def test_wrong_input_length_y_call_interp1d_unc(interp_inputs):
         interp1d_unc(**interp_inputs)
 
 
-@example(
-    {
-        "kind": "linear",
-        "t": array([0.00000000e000, 2.22044605e284]),
-        "t_new": array([0.00000000e000, 4.93038066e268]),
-        "uy": array([0.00000000e000, 2.22044605e284]),
-        "y": array([0.00000000e000, 2.22044605e284]),
-    }
-)
 @given(timestamps_values_uncertainties_kind())
 def test_t_new_below_range_interp1d_unc(interp_inputs):
-    # Ensure at least two different timestamps in each series.
-    assume(not (interp_inputs["t"][0] == interp_inputs["t"][-1]))
-    assume(not (interp_inputs["t_new"][0] == interp_inputs["t_new"][-1]))
-
     # Check erroneous calls with t_new's minimum below t's minimum. The complicated
     # translation follows from covering all cases with very large values in and
     # very large differences between t_new and t.
@@ -137,10 +129,6 @@ def test_t_new_below_range_interp1d_unc(interp_inputs):
 
 @given(timestamps_values_uncertainties_kind())
 def test_t_new_above_range_interp1d_unc(interp_inputs):
-    # Ensure at least two different timestamps in each series.
-    assume(not (interp_inputs["t"][0] == interp_inputs["t"][-1]))
-    assume(not (interp_inputs["t_new"][0] == interp_inputs["t_new"][-1]))
-
     # Check erroneous calls with t_new's maximum above t's maximum. The complicated
     # translation follows from covering all cases with very large values in and very
     # large differences between t_new and t.
@@ -156,8 +144,8 @@ def test_t_new_above_range_interp1d_unc(interp_inputs):
 @given(timestamps_values_uncertainties_kind())
 def test_wrong_input_length_uy_call_interp1d_unc(interp_inputs):
     # Ensure at least two different timestamps in each series.
-    assume(not (interp_inputs["t"][0] == interp_inputs["t"][-1]))
-    assume(not (interp_inputs["t_new"][0] == interp_inputs["t_new"][-1]))
+    # assume(not (interp_inputs["t"][0] == interp_inputs["t"][-1]))
+    # assume(not (interp_inputs["t_new"][0] == interp_inputs["t_new"][-1]))
 
     # Check erroneous calls with unequally long inputs.
     interp_inputs["uy"] = np.tile(interp_inputs["uy"], 2)
@@ -168,8 +156,8 @@ def test_wrong_input_length_uy_call_interp1d_unc(interp_inputs):
 @given(timestamps_values_uncertainties_kind(sorted_timestamps=False))
 def test_wrong_input_order_call_interp1d_unc(interp_inputs):
     # Ensure at least two different timestamps in each series.
-    assume(not (interp_inputs["t"][0] == interp_inputs["t"][-1]))
-    assume(not (interp_inputs["t_new"][0] == interp_inputs["t_new"][-1]))
+    # assume(not (interp_inputs["t"][0] == interp_inputs["t"][-1]))
+    # assume(not (interp_inputs["t_new"][0] == interp_inputs["t_new"][-1]))
 
     # Ensure the timestamps are not in ascending order.
     assume(not np.all(interp_inputs["t"][1:] >= interp_inputs["t"][:-1]))
@@ -182,8 +170,8 @@ def test_wrong_input_order_call_interp1d_unc(interp_inputs):
 @given(timestamps_values_uncertainties_kind(kind_tuple=("previous", "next", "nearest")))
 def test_trivial_in_interp1d_unc(interp_inputs):
     # Ensure at least two different timestamps in each series.
-    assume(not (interp_inputs["t"][0] == interp_inputs["t"][-1]))
-    assume(not (interp_inputs["t_new"][0] == interp_inputs["t_new"][-1]))
+    # assume(not (interp_inputs["t"][0] == interp_inputs["t"][-1]))
+    # assume(not (interp_inputs["t_new"][0] == interp_inputs["t_new"][-1]))
 
     y_new, uy_new = interp1d_unc(**interp_inputs)[1:3]
     # Check if all 'interpolated' values are present in the actual values.
@@ -194,8 +182,8 @@ def test_trivial_in_interp1d_unc(interp_inputs):
 @given(timestamps_values_uncertainties_kind(kind_tuple=["linear"]))
 def test_linear_in_interp1d_unc(interp_inputs):
     # Ensure at least two different timestamps in each series.
-    assume(not (interp_inputs["t"][0] == interp_inputs["t"][-1]))
-    assume(not (interp_inputs["t_new"][0] == interp_inputs["t_new"][-1]))
+    # assume(not (interp_inputs["t"][0] == interp_inputs["t"][-1]))
+    # assume(not (interp_inputs["t_new"][0] == interp_inputs["t_new"][-1]))
 
     y_new, uy_new = interp1d_unc(**interp_inputs)[1:3]
     # Check if all interpolated values lie in the range of the original values.
@@ -225,8 +213,8 @@ def test_linear_uy_in_interp1d_unc(n,):
 )
 def test_raise_not_implemented_yet_interp1d(interp_inputs):
     # Ensure at least two different timestamps in each series.
-    assume(not (interp_inputs["t"][0] == interp_inputs["t"][-1]))
-    assume(not (interp_inputs["t_new"][0] == interp_inputs["t_new"][-1]))
+    # assume(not (interp_inputs["t"][0] == interp_inputs["t"][-1]))
+    # assume(not (interp_inputs["t_new"][0] == interp_inputs["t_new"][-1]))
 
     # Check that not implemented versions raise exceptions.
     with raises(NotImplementedError):

--- a/test/test_interpolation.py
+++ b/test/test_interpolation.py
@@ -85,10 +85,6 @@ def timestamps_values_uncertainties_kind(
 
 @given(timestamps_values_uncertainties_kind())
 def test_usual_call(interp_inputs):
-    # Ensure at least two different timestamps in each series.
-    # assume(not (interp_inputs["t"][0] == interp_inputs["t"][-1]))
-    # assume(not (interp_inputs["t_new"][0] == interp_inputs["t_new"][-1]))
-
     t_new, y_new, uy_new = interp1d_unc(**interp_inputs)
     # Check the equal dimensions of the minimum calls output.
     assert len(t_new) == len(y_new) == len(uy_new)
@@ -103,10 +99,6 @@ def test_too_few_timestamps_call(interp_inputs):
 
 @given(timestamps_values_uncertainties_kind())
 def test_wrong_input_length_y_call_interp1d_unc(interp_inputs):
-    # Ensure at least two different timestamps in each series.
-    # assume(not (interp_inputs["t"][0] == interp_inputs["t"][-1]))
-    # assume(not (interp_inputs["t_new"][0] == interp_inputs["t_new"][-1]))
-
     # Check erroneous calls with unequally long inputs.
     interp_inputs["y"] = np.tile(interp_inputs["y"], 2)
     with raises(ValueError):
@@ -143,10 +135,6 @@ def test_t_new_above_range_interp1d_unc(interp_inputs):
 
 @given(timestamps_values_uncertainties_kind())
 def test_wrong_input_length_uy_call_interp1d_unc(interp_inputs):
-    # Ensure at least two different timestamps in each series.
-    # assume(not (interp_inputs["t"][0] == interp_inputs["t"][-1]))
-    # assume(not (interp_inputs["t_new"][0] == interp_inputs["t_new"][-1]))
-
     # Check erroneous calls with unequally long inputs.
     interp_inputs["uy"] = np.tile(interp_inputs["uy"], 2)
     with raises(ValueError):
@@ -155,10 +143,6 @@ def test_wrong_input_length_uy_call_interp1d_unc(interp_inputs):
 
 @given(timestamps_values_uncertainties_kind(sorted_timestamps=False))
 def test_wrong_input_order_call_interp1d_unc(interp_inputs):
-    # Ensure at least two different timestamps in each series.
-    # assume(not (interp_inputs["t"][0] == interp_inputs["t"][-1]))
-    # assume(not (interp_inputs["t_new"][0] == interp_inputs["t_new"][-1]))
-
     # Ensure the timestamps are not in ascending order.
     assume(not np.all(interp_inputs["t"][1:] >= interp_inputs["t"][:-1]))
     # Check erroneous calls with descending timestamps.
@@ -169,10 +153,6 @@ def test_wrong_input_order_call_interp1d_unc(interp_inputs):
 
 @given(timestamps_values_uncertainties_kind(kind_tuple=("previous", "next", "nearest")))
 def test_trivial_in_interp1d_unc(interp_inputs):
-    # Ensure at least two different timestamps in each series.
-    # assume(not (interp_inputs["t"][0] == interp_inputs["t"][-1]))
-    # assume(not (interp_inputs["t_new"][0] == interp_inputs["t_new"][-1]))
-
     y_new, uy_new = interp1d_unc(**interp_inputs)[1:3]
     # Check if all 'interpolated' values are present in the actual values.
     assert np.all(np.isin(y_new, interp_inputs["y"]))
@@ -181,10 +161,6 @@ def test_trivial_in_interp1d_unc(interp_inputs):
 
 @given(timestamps_values_uncertainties_kind(kind_tuple=["linear"]))
 def test_linear_in_interp1d_unc(interp_inputs):
-    # Ensure at least two different timestamps in each series.
-    # assume(not (interp_inputs["t"][0] == interp_inputs["t"][-1]))
-    # assume(not (interp_inputs["t_new"][0] == interp_inputs["t_new"][-1]))
-
     y_new, uy_new = interp1d_unc(**interp_inputs)[1:3]
     # Check if all interpolated values lie in the range of the original values.
     assert np.all(np.amin(interp_inputs["y"]) <= y_new)
@@ -212,10 +188,6 @@ def test_linear_uy_in_interp1d_unc(n,):
     )
 )
 def test_raise_not_implemented_yet_interp1d(interp_inputs):
-    # Ensure at least two different timestamps in each series.
-    # assume(not (interp_inputs["t"][0] == interp_inputs["t"][-1]))
-    # assume(not (interp_inputs["t_new"][0] == interp_inputs["t_new"][-1]))
-
     # Check that not implemented versions raise exceptions.
     with raises(NotImplementedError):
         interp1d_unc(**interp_inputs)

--- a/test/test_interpolation.py
+++ b/test/test_interpolation.py
@@ -1,9 +1,9 @@
 from typing import Dict, Optional, Tuple, Union
-from numpy import array
+
 import hypothesis.extra.numpy as hnp
 import hypothesis.strategies as st
 import numpy as np
-from hypothesis import assume, example, given
+from hypothesis import assume, given
 from hypothesis.strategies import composite
 from pytest import raises
 

--- a/test/test_interpolation.py
+++ b/test/test_interpolation.py
@@ -45,7 +45,7 @@ def timestamps_values_uncertainties_kind(
         dt, kind for interp1d_unc()
     """
     # Set the maximum absolute value for floats to be really unique in calculations.
-    float_abs_max = 1e256
+    float_abs_max = 1e128
     # Set all common parameters for timestamps, measurements values and associated
     # uncertainties.
     shape_for_timestamps = hnp.array_shapes(

--- a/test/test_make_equidistant.py
+++ b/test/test_make_equidistant.py
@@ -47,7 +47,7 @@ def timestamps_values_uncertainties_kind(
         dt, kind for make_equidistant()
     """
     # Set the maximum absolute value for floats to be really unique in calculations.
-    float_abs_max = 1e300
+    float_abs_max = 1e256
     # Set all common parameters for timestamps, measurements values and associated
     # uncertainties including allowed ranges and number of elements.
     shape_for_timestamps = hnp.array_shapes(

--- a/test/test_make_equidistant.py
+++ b/test/test_make_equidistant.py
@@ -46,6 +46,8 @@ def timestamps_values_uncertainties_kind(
         A dict containing the randomly generated expected input parameters t, y, uy,
         dt, kind for make_equidistant()
     """
+    # Set the maximum absolute value for floats to be really unique in calculations.
+    float_abs_max = 1e300
     # Set all common parameters for timestamps, measurements values and associated
     # uncertainties including allowed ranges and number of elements.
     shape_for_timestamps = hnp.array_shapes(
@@ -55,7 +57,10 @@ def timestamps_values_uncertainties_kind(
         "dtype": np.float,
         "shape": shape_for_timestamps,
         "elements": st.floats(
-            min_value=0, max_value=1e300, allow_nan=False, allow_infinity=False
+            min_value=-float_abs_max,
+            max_value=float_abs_max,
+            allow_nan=False,
+            allow_infinity=False,
         ),
         "unique": True,
     }
@@ -94,7 +99,7 @@ def test_too_short_call_make_equidistant(interp_inputs):
 @given(timestamps_values_uncertainties_kind())
 def test_full_call_make_equidistant(interp_inputs):
     # Ensure at least two different timestamps in the series.
-    assume(not (interp_inputs["t"][0] == interp_inputs["t"][-1]))
+    # assume(not (interp_inputs["t"][0] == interp_inputs["t"][-1]))
 
     t_new, y_new, uy_new = make_equidistant(**interp_inputs)
     # Check the equal dimensions of the minimum calls output.
@@ -104,7 +109,7 @@ def test_full_call_make_equidistant(interp_inputs):
 @given(timestamps_values_uncertainties_kind())
 def test_wrong_input_lengths_call_make_equidistant(interp_inputs):
     # Ensure at least two different timestamps in the series.
-    assume(not (interp_inputs["t"][0] == interp_inputs["t"][-1]))
+    # assume(not (interp_inputs["t"][0] == interp_inputs["t"][-1]))
 
     # Check erroneous calls with unequally long inputs.
     with raises(ValueError):
@@ -116,7 +121,7 @@ def test_wrong_input_lengths_call_make_equidistant(interp_inputs):
 @given(timestamps_values_uncertainties_kind(sorted_timestamps=False))
 def test_wrong_input_order_call_make_equidistant(interp_inputs):
     # Ensure at least two different timestamps in the series.
-    assume(not (interp_inputs["t"][0] == interp_inputs["t"][-1]))
+    # assume(not (interp_inputs["t"][0] == interp_inputs["t"][-1]))
 
     # Ensure the timestamps are not in ascending order.
     assume(not np.all(interp_inputs["t"][1:] >= interp_inputs["t"][:-1]))
@@ -129,7 +134,7 @@ def test_wrong_input_order_call_make_equidistant(interp_inputs):
 @given(timestamps_values_uncertainties_kind())
 def test_t_new_to_dt_make_equidistant(interp_inputs):
     # Ensure at least two different timestamps in the series.
-    assume(not (interp_inputs["t"][0] == interp_inputs["t"][-1]))
+    # assume(not (interp_inputs["t"][0] == interp_inputs["t"][-1]))
 
     t_new = make_equidistant(**interp_inputs)[0]
     delta_t_new = np.diff(t_new)
@@ -140,7 +145,7 @@ def test_t_new_to_dt_make_equidistant(interp_inputs):
 @given(timestamps_values_uncertainties_kind(kind_tuple=("previous", "next", "nearest")))
 def test_prev_in_make_equidistant(interp_inputs):
     # Ensure at least two different timestamps in the series.
-    assume(not (interp_inputs["t"][0] == interp_inputs["t"][-1]))
+    # assume(not (interp_inputs["t"][0] == interp_inputs["t"][-1]))
 
     y_new, uy_new = make_equidistant(**interp_inputs)[1:3]
     # Check if all 'interpolated' values are present in the actual values.
@@ -151,7 +156,7 @@ def test_prev_in_make_equidistant(interp_inputs):
 @given(timestamps_values_uncertainties_kind(kind_tuple=["linear"]))
 def test_linear_in_make_equidistant(interp_inputs):
     # Ensure at least two different timestamps in the series.
-    assume(not (interp_inputs["t"][0] == interp_inputs["t"][-1]))
+    # assume(not (interp_inputs["t"][0] == interp_inputs["t"][-1]))
 
     y_new, uy_new = make_equidistant(**interp_inputs)[1:3]
     # Check if all interpolated values lie in the range of the original values.
@@ -180,7 +185,7 @@ def test_linear_uy_in_make_equidistant(n):
 )
 def test_raise_not_implemented_yet_make_equidistant(interp_inputs):
     # Ensure at least two different timestamps in the series.
-    assume(not (interp_inputs["t"][0] == interp_inputs["t"][-1]))
+    # assume(not (interp_inputs["t"][0] == interp_inputs["t"][-1]))
     # Check that not implemented versions raise exceptions or alternatively if values
     # don't allow for proper execution ValueErrors.
     with raises(NotImplementedError):

--- a/test/test_make_equidistant.py
+++ b/test/test_make_equidistant.py
@@ -47,7 +47,7 @@ def timestamps_values_uncertainties_kind(
         dt, kind for make_equidistant()
     """
     # Set the maximum absolute value for floats to be really unique in calculations.
-    float_abs_max = 1e256
+    float_abs_max = 1e128
     # Set all common parameters for timestamps, measurements values and associated
     # uncertainties including allowed ranges and number of elements.
     shape_for_timestamps = hnp.array_shapes(

--- a/test/test_make_equidistant.py
+++ b/test/test_make_equidistant.py
@@ -98,9 +98,6 @@ def test_too_short_call_make_equidistant(interp_inputs):
 
 @given(timestamps_values_uncertainties_kind())
 def test_full_call_make_equidistant(interp_inputs):
-    # Ensure at least two different timestamps in the series.
-    # assume(not (interp_inputs["t"][0] == interp_inputs["t"][-1]))
-
     t_new, y_new, uy_new = make_equidistant(**interp_inputs)
     # Check the equal dimensions of the minimum calls output.
     assert len(t_new) == len(y_new) == len(uy_new)
@@ -108,9 +105,6 @@ def test_full_call_make_equidistant(interp_inputs):
 
 @given(timestamps_values_uncertainties_kind())
 def test_wrong_input_lengths_call_make_equidistant(interp_inputs):
-    # Ensure at least two different timestamps in the series.
-    # assume(not (interp_inputs["t"][0] == interp_inputs["t"][-1]))
-
     # Check erroneous calls with unequally long inputs.
     with raises(ValueError):
         y_wrong = np.tile(interp_inputs["y"], 2)
@@ -120,9 +114,6 @@ def test_wrong_input_lengths_call_make_equidistant(interp_inputs):
 
 @given(timestamps_values_uncertainties_kind(sorted_timestamps=False))
 def test_wrong_input_order_call_make_equidistant(interp_inputs):
-    # Ensure at least two different timestamps in the series.
-    # assume(not (interp_inputs["t"][0] == interp_inputs["t"][-1]))
-
     # Ensure the timestamps are not in ascending order.
     assume(not np.all(interp_inputs["t"][1:] >= interp_inputs["t"][:-1]))
     # Check erroneous calls with descending timestamps.
@@ -133,9 +124,6 @@ def test_wrong_input_order_call_make_equidistant(interp_inputs):
 
 @given(timestamps_values_uncertainties_kind())
 def test_t_new_to_dt_make_equidistant(interp_inputs):
-    # Ensure at least two different timestamps in the series.
-    # assume(not (interp_inputs["t"][0] == interp_inputs["t"][-1]))
-
     t_new = make_equidistant(**interp_inputs)[0]
     delta_t_new = np.diff(t_new)
     # Check if the new timestamps are ascending.
@@ -144,9 +132,6 @@ def test_t_new_to_dt_make_equidistant(interp_inputs):
 
 @given(timestamps_values_uncertainties_kind(kind_tuple=("previous", "next", "nearest")))
 def test_prev_in_make_equidistant(interp_inputs):
-    # Ensure at least two different timestamps in the series.
-    # assume(not (interp_inputs["t"][0] == interp_inputs["t"][-1]))
-
     y_new, uy_new = make_equidistant(**interp_inputs)[1:3]
     # Check if all 'interpolated' values are present in the actual values.
     assert np.all(np.isin(y_new, interp_inputs["y"]))
@@ -155,9 +140,6 @@ def test_prev_in_make_equidistant(interp_inputs):
 
 @given(timestamps_values_uncertainties_kind(kind_tuple=["linear"]))
 def test_linear_in_make_equidistant(interp_inputs):
-    # Ensure at least two different timestamps in the series.
-    # assume(not (interp_inputs["t"][0] == interp_inputs["t"][-1]))
-
     y_new, uy_new = make_equidistant(**interp_inputs)[1:3]
     # Check if all interpolated values lie in the range of the original values.
     assert np.all(np.amin(interp_inputs["y"]) <= y_new)
@@ -184,8 +166,6 @@ def test_linear_uy_in_make_equidistant(n):
     )
 )
 def test_raise_not_implemented_yet_make_equidistant(interp_inputs):
-    # Ensure at least two different timestamps in the series.
-    # assume(not (interp_inputs["t"][0] == interp_inputs["t"][-1]))
     # Check that not implemented versions raise exceptions or alternatively if values
     # don't allow for proper execution ValueErrors.
     with raises(NotImplementedError):


### PR DESCRIPTION
There were some unneeded bits of code in the test for interpolation and actually one corner case bug in the actual interpolation when several and not only the last interpolation interval degenerated to one start and end node. This is now resolved.

In addition we reduced and unified the floats ranges for the tests of `interp1d_unc()` and `make_equidistant()` where the latter were non-negative until now but we could actually allow for negativ timestamps as well. In the range of `[-1e300, 1e300]` from time to time overflow errors occured in the calculations so we reduced the range to `[-1e256, 1e256]`.