### PR TITLE
Introduce test for signal example

### DIFF
--- a/examples/working_with_signals.py
+++ b/examples/working_with_signals.py
@@ -16,24 +16,29 @@ from PyDynamic import rect
 from PyDynamic.signals import Signal
 
 
-N = 1024
-delta_t = 0.01
-t = np.arange(0, N * delta_t, delta_t)
-x = rect(t, delta_t * N // 4, delta_t * N // 4 * 3)
-ux = 0.02
-signal = Signal(t, x, Ts=delta_t, uncertainty=ux)
-b = dsp.firls(
-    15,
-    [0, 0.2 * signal.Fs / 2, 0.25 * signal.Fs / 2, signal.Fs / 2],
-    [1, 1, 0, 0],
-    nyq=signal.Fs / 2,
-)
-Ub = np.diag(b * 1e-1)
-signal.apply_filter(b, filter_uncertainty=Ub)
-signal.plot_uncertainty()
-plt.show()
-bl, al = dsp.bessel(4, 0.2)
-Ul = np.diag(np.r_[al[1:] * 1e-3, bl * 1e-2] ** 2)
-signal.apply_filter(bl, al, filter_uncertainty=Ul)
-signal.plot_uncertainty(fignr=3)
-plt.show()
+def demonstrate_signal():
+    N = 1024
+    delta_t = 0.01
+    t = np.arange(0, N * delta_t, delta_t)
+    x = rect(t, delta_t * N // 4, delta_t * N // 4 * 3)
+    ux = 0.02
+    signal = Signal(t, x, Ts=delta_t, uncertainty=ux)
+    b = dsp.firls(
+        15,
+        [0, 0.2 * signal.Fs / 2, 0.25 * signal.Fs / 2, signal.Fs / 2],
+        [1, 1, 0, 0],
+        nyq=signal.Fs / 2,
+    )
+    Ub = np.diag(b * 1e-1)
+    signal.apply_filter(b, filter_uncertainty=Ub)
+    signal.plot_uncertainty()
+    plt.show()
+    bl, al = dsp.bessel(4, 0.2)
+    Ul = np.diag(np.r_[al[1:] * 1e-3, bl * 1e-2] ** 2)
+    signal.apply_filter(bl, al, filter_uncertainty=Ul)
+    signal.plot_uncertainty(fignr=3)
+    plt.show()
+
+
+if __name__ == "__main__":
+    demonstrate_signal()

--- a/test/test_signals.py
+++ b/test/test_signals.py
@@ -4,9 +4,15 @@
 import numpy as np
 from numpy.testing import assert_almost_equal
 from pytest import approx
+from examples.working_with_signals import demonstrate_signal
 
-from PyDynamic.misc.testsignals import shocklikeGaussian, GaussianPulse, rect, \
-    squarepulse, sine
+from PyDynamic.misc.testsignals import (
+    shocklikeGaussian,
+    GaussianPulse,
+    rect,
+    squarepulse,
+    sine,
+)
 
 N = 2048
 Ts = 0.01
@@ -27,12 +33,11 @@ def test_shocklikeGaussian():
     # zero noise
     x = shocklikeGaussian(time, t0, m0, sigma, noise=0.0)
     assert_almost_equal(np.max(x), m0)
-    assert np.std(x[:N // 10]) < 1e-10
+    assert np.std(x[: N // 10]) < 1e-10
     # noisy signal
     nstd = 1e-2
     x = shocklikeGaussian(time, t0, m0, sigma, noise=nstd)
-    assert_almost_equal(
-        np.round(np.std(x[:N // 10]) * 100) / 100, nstd)
+    assert_almost_equal(np.round(np.std(x[: N // 10]) * 100) / 100, nstd)
 
 
 def test_GaussianPulse():
@@ -42,12 +47,11 @@ def test_GaussianPulse():
     x = GaussianPulse(time, t0, m0, sigma, noise=0.0)
     assert_almost_equal(np.max(x), m0)
     assert_almost_equal(time[x.argmax()], t0)
-    assert np.std(x[:N // 10]) < 1e-10
+    assert np.std(x[: N // 10]) < 1e-10
     # noisy signal
     nstd = 1e-2
     x = GaussianPulse(time, t0, m0, sigma, noise=nstd)
-    assert_almost_equal(
-        np.round(np.std(x[:N // 10]) * 100) / 100, nstd)
+    assert_almost_equal(np.round(np.std(x[: N // 10]) * 100) / 100, nstd)
 
 
 def test_rect():
@@ -136,3 +140,7 @@ class TestSine:
         sine(time, amp, freq=freq, noise=noise)
         sine(time, freq=freq, noise=noise)
         sine(time, amp=amp, freq=freq, noise=noise)
+
+
+def test_signal_example():
+    demonstrate_signal()


### PR DESCRIPTION
Now that we have a home for [the example of our experimental class `Signal`](https://github.com/PTB-PSt1/PyDynamic/blob/master/examples/working_with_signals.py), we should at least call this example once in the test suite.