### PR TITLE
Add extrapolation to interp1d_unc

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -25,4 +25,4 @@ python:
 sphinx:
   builder: html
   configuration: doc/conf.py
-  fail_on_warning: false
+  fail_on_warning: true

--- a/PyDynamic/misc/tools.py
+++ b/PyDynamic/misc/tools.py
@@ -245,7 +245,8 @@ def make_equidistant(t, y, uy, dt=5e-2, kind="linear"):
     t_new = np.arange(np.min(t), np.max(t), dt)
 
     # Since np.arange in overflow situations results in the last value not guaranteed to
-    # be smaller than t[-1], we need to check for this and delete this unexpected value.
+    # be smaller than t's maximum', we need to check for this and delete this
+    # unexpected value.
     if t_new[-1] > np.max(t):
         t_new = t_new[:-1]
 

--- a/PyDynamic/uncertainty/interpolation.py
+++ b/PyDynamic/uncertainty/interpolation.py
@@ -24,27 +24,52 @@ def interp1d_unc(
     y: np.ndarray,
     uy: np.ndarray,
     kind: Optional[str] = "linear",
+    bounds_error: Optional[bool] = None,
+    fill_value: Optional[bool] = np.nan,
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Interpolate arbitrary time series considering the associated uncertainties
+    r"""Interpolate a 1-D function considering the associated uncertainties
 
-    The interpolation timestamps must lie within the range of the original
-    timestamps. In addition, at least two of each of the original timestamps,
-    measured values and associated measurement uncertainties are required and an
-    equal number of each of these three.
+    t and y are arrays of values used to approximate some function :math:`f \colon y
+    = f(x)`.
+
+    Note that calling :func:`interp1d_unc` with NaNs present in input values
+    results in undefined behaviour.
+
+    At least two of each of the original timestamps (or frequencies), values and
+    associated uncertainties are required and an equal number of each of these three.
 
     Parameters
     ----------
-        t_new: (M,) array_like
-            The timestamps at which to evaluate the interpolated values.
-        t: (N,) array_like
-            timestamps in ascending order
-        y: (N,) array_like
-            corresponding measurement values
-        uy: (N,) array_like
-            corresponding measurement values' uncertainties
-        kind: str, optional
-            Specifies the kind of interpolation for the measurement values
-            as a string ('previous', 'next', 'nearest' or 'linear').
+        t_new : (M,) array_like
+            A 1-D array of real values representing the timestamps (or frequencies) at
+            which to evaluate the interpolated values.
+        t : (N,) array_like
+            A 1-D array of real values representing timestamps (or frequencies) in
+            ascending order.
+        y : (N,) array_like
+            A 1-D array of real values. The length of y must be equal to the length
+            of t_new
+        uy : (N,) array_like
+            A 1-D array of real values representing the uncertainties associated with y.
+        kind : str, optional
+            Specifies the kind of interpolation for y as a string ('previous',
+            'next', 'nearest' or 'linear'). Default is ‘linear’.
+        bounds_error : bool, optional
+            If True, a ValueError is raised any time interpolation is attempted on a
+            value outside of the range of x (where extrapolation is necessary). If
+            False, out of bounds values are assigned fill_value. By default, an error
+            is raised unless `fill_value="extrapolate"`.
+        fill_value : array-like or (array-like, array_like) or “extrapolate”, optional
+
+            - if a ndarray (or float), this value will be used to fill in for
+              requested points outside of the data range. If not provided, then the
+              default is NaN.
+            - If a two-element tuple, then the first element is used as a fill value
+              for `t_new < t[0]` and the second element is used for `t_new > t[-1]`.
+              Anything that is not a 2-element tuple (e.g., list or ndarray, regardless
+              of shape) is taken to be a single array-like argument meant to be used
+              for both bounds as `below, above = fill_value, fill_value`.
+            - If “extrapolate”, then points outside the data range will be extrapolated.
 
     Returns
     -------
@@ -78,7 +103,9 @@ def interp1d_unc(
             "as array of measurement values."
         )
     # Interpolate measurement values in the desired fashion.
-    interp_y = interp1d(t, y, kind=kind)
+    interp_y = interp1d(
+        t, y, kind=kind, bounds_error=bounds_error, fill_value=fill_value
+    )
     y_new = interp_y(t_new)
 
     if kind in ("previous", "next", "nearest"):

--- a/PyDynamic/uncertainty/interpolation.py
+++ b/PyDynamic/uncertainty/interpolation.py
@@ -119,13 +119,6 @@ def interp1d_unc(
         y = np.take(y, ind)
         uy = np.take(uy, ind)
     # ----------------------------------------------------------------------------------
-    # Check for ascending order of timestamps (or frequencies), because SciPy does not
-    # do that.
-    else:
-        if not np.all(t[1:] >= t[:-1]):
-            raise ValueError(
-                "Array of timestamps (or frequencies) needs to be in ascending order."
-            )
     # Check for proper dimensions of inputs which are not checked as desired by SciPy.
     if not len(y) == len(uy):
         raise ValueError(

--- a/PyDynamic/uncertainty/interpolation.py
+++ b/PyDynamic/uncertainty/interpolation.py
@@ -27,6 +27,7 @@ def interp1d_unc(
     copy=True,
     bounds_error: Optional[bool] = None,
     fill_value: Optional[bool] = np.nan,
+    fill_unc: Optional[bool] = np.nan,
     assume_sorted: Optional[bool] = True,
     return_c: Optional[bool] = False,
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
@@ -75,7 +76,11 @@ def interp1d_unc(
               Anything that is not a 2-element tuple (e.g., list or ndarray, regardless
               of shape) is taken to be a single array-like argument meant to be used
               for both bounds as `below, above = fill_value, fill_value`.
-            - If “extrapolate”, then points outside the data range will be extrapolated.
+            - If “extrapolate”, then points outside the data range will be set
+              to the first or last element of the values.
+
+        fill_unc : array-like or (array-like, array_like) or “extrapolate”, optional
+            Usage and behaviour as described in `fill_value` but for the uncertainties
 
         assume_sorted : bool, optional
             If False, values of t can be in any order and they are sorted first. If
@@ -129,23 +134,26 @@ def interp1d_unc(
         )
 
     # Set up parameter dicts for calls of interp1d. We use it for actual
-    # "interpolation" (i.e. look-ups) in trivial cases and in the linear case to check
-    # for bound errors.
+    # "interpolation" (i.e. look-ups) in trivial cases and in the linear case to
+    # extrapolate.
     interp1d_params = {
         "kind": kind,
         "copy": False,
         "bounds_error": bounds_error,
-        "fill_value": fill_value,
         "assume_sorted": True,
     }
 
-    # Inter- or extrapolate values in the desired fashion.
-    interp_y = interp1d(t, y, **interp1d_params)
+    # Inter- or extrapolate values in the desired fashion and especially ensure
+    # constant behaviour outside the original bounds. For this to rely on SciPy's
+    # handling of fill values we set those explicitly to boundary values of y.
+    if fill_value == "extrapolate":
+        fill_value = y[0], y[-1]
+    interp_y = interp1d(t, y, fill_value=fill_value, **interp1d_params)
     y_new = interp_y(t_new)
 
     if kind in ("previous", "next", "nearest"):
         # Look up uncertainties.
-        interp_uy = interp1d(t, uy, **interp1d_params)
+        interp_uy = interp1d(t, uy, fill_value=fill_unc, **interp1d_params)
         uy_new = interp_uy(t_new)
     elif kind == "linear":
         # This following section is taken from scipy.interpolate.interp1d to
@@ -168,10 +176,10 @@ def interp1d_unc(
         t_lo = t[lo]
         t_hi = t[hi]
         # ------------------------------------------------------------------------------
-        # Now we extend the interpolation from scipy.interpolate.interp1d by
-        # computing the associated interpolated uncertainties following White, 2017.
-        uy_prev_sqr = uy[t_new_indices - 1] ** 2
-        uy_next_sqr = uy[t_new_indices] ** 2
+        # Now we extend the interpolation from scipy.interpolate.interp1d by first
+        # extrapolating the according values if required and then computing the
+        # associated interpolated uncertainties following White, 2017.
+        uy_new = np.empty_like(y_new)
 
         if return_c:
             raise NotImplementedError(
@@ -179,9 +187,31 @@ def interp1d_unc(
                 "present in the near future."
             )
 
-        uy_new = np.sqrt(
-            (t_new - t_hi) ** 2 * uy_prev_sqr + (t_new - t_lo) ** 2 * uy_next_sqr
-        ) / (t_hi - t_lo)
+        # Calculate boolean arrays of indices from t_new which are outside t's bounds...
+        extrapolation_range = (t_new < np.min(t)) | (t_new > np.max(t))
+        # .. and inside t's bounds.
+        interpolation_range = ~extrapolation_range
+
+        # If extrapolation is needed, rely on SciPy's handling of fill values,
+        # which we prepared in advance.
+        if np.any(extrapolation_range):
+            # Set boundary values of uy for fill values to ensure constant behaviour
+            # outside original bounds.
+            if fill_unc == "extrapolate":
+                fill_unc = uy[0], uy[-1]
+            interp_uy = interp1d(t, uy, fill_value=fill_unc, **interp1d_params)
+            uy_new[extrapolation_range] = interp_uy(t_new[extrapolation_range])
+
+        # If interpolation is needed, compute uncertainties following White, 2017.
+        if np.any(interpolation_range):
+            uy_prev_sqr = uy[lo] ** 2
+            uy_next_sqr = uy[hi] ** 2
+            uy_new[interpolation_range] = np.sqrt(
+                (t_new[interpolation_range] - t_hi[interpolation_range]) ** 2
+                * uy_prev_sqr[interpolation_range]
+                + (t_new[interpolation_range] - t_lo[interpolation_range]) ** 2
+                * uy_next_sqr[interpolation_range]
+            ) / (t_hi[interpolation_range] - t_lo[interpolation_range])
     else:
         raise NotImplementedError(
             "%s is unsupported yet. Let us know, that you need it." % kind

--- a/PyDynamic/uncertainty/interpolation.py
+++ b/PyDynamic/uncertainty/interpolation.py
@@ -37,8 +37,8 @@ def interp1d_unc(
     Note that calling :func:`interp1d_unc` with NaNs present in input values
     results in undefined behaviour.
 
-    At least two of each of the original timestamps (or frequencies), values and
-    associated uncertainties are required and an equal number of each of these three.
+    An equal number of each of the original timestamps (or frequencies), values and
+    associated uncertainties is required.
 
     Parameters
     ----------
@@ -104,7 +104,7 @@ def interp1d_unc(
         t = t[ind]
         y = np.take(y, ind)
     # ----------------------------------------------------------------------------------
-    # Check for ascending order of timestamps, because scipy does not do that.
+    # Check for ascending order of timestamps, because SciPy does not do that.
     else:
         if not np.all(t[1:] >= t[:-1]):
             raise ValueError("Array of timestamps needs to be in ascending order.")

--- a/PyDynamic/uncertainty/interpolation.py
+++ b/PyDynamic/uncertainty/interpolation.py
@@ -51,7 +51,7 @@ def interp1d_unc(
             ascending order.
         y : (N,) array_like
             A 1-D array of real values. The length of y must be equal to the length
-            of t
+            of t.
         uy : (N,) array_like
             A 1-D array of real values representing the uncertainties associated with y.
         kind : str, optional
@@ -91,11 +91,11 @@ def interp1d_unc(
             True, t has to be an array of monotonically increasing values.
         return_c : bool, optional
             This feature is not yet implemented, but will be provided in the near
-            future. Setting return_c to True thus results in an exception being
+            future. Setting `return_c` to True thus results in an exception being
             thrown for now.
             If True, return sensitivity coefficients for later use. If False
             sensitivity coefficients are not returned and internal computation is
-            a little more efficient. Default is False.
+            more efficient.
 
     Returns
     -------

--- a/PyDynamic/uncertainty/interpolation.py
+++ b/PyDynamic/uncertainty/interpolation.py
@@ -26,8 +26,8 @@ def interp1d_unc(
     kind: Optional[str] = "linear",
     copy=True,
     bounds_error: Optional[bool] = None,
-    fill_value: Optional[bool] = np.nan,
-    fill_unc: Optional[bool] = np.nan,
+    fill_value: Optional[Union[float, Tuple[float, float], str]] = np.nan,
+    fill_unc: Optional[Union[float, Tuple[float, float], str]] = np.nan,
     assume_sorted: Optional[bool] = True,
     return_c: Optional[bool] = False,
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:

--- a/PyDynamic/uncertainty/interpolation.py
+++ b/PyDynamic/uncertainty/interpolation.py
@@ -87,16 +87,7 @@ def interp1d_unc(
     # Check for ascending order of timestamps.
     if not np.all(t[1:] >= t[:-1]):
         raise ValueError("Array of timestamps needs to be in ascending order.")
-    # Check for proper dimensions of inputs.
-    if ((t.min() > t_new) | (t.max() < t_new)).any():
-        raise ValueError(
-            "Array of interpolation timestamps must be in the range of original "
-            "timestamps."
-        )
-    if not len(t) == len(y):
-        raise ValueError(
-            "Array of measurement values must be same length as array of timestamps."
-        )
+    # Check for proper dimensions of inputs which are not checked as desired by SciPy.
     if not len(y) == len(uy):
         raise ValueError(
             "Array of associated measurement values' uncertainties must be same length "

--- a/PyDynamic/uncertainty/interpolation.py
+++ b/PyDynamic/uncertainty/interpolation.py
@@ -138,18 +138,16 @@ def interp1d_unc(
         "fill_value": fill_value,
         "assume_sorted": True,
     }
+
+    # Inter- or extrapolate values in the desired fashion.
     interp_y = interp1d(t, y, **interp1d_params)
+    y_new = interp_y(t_new)
 
     if kind in ("previous", "next", "nearest"):
-        # Look up values.
-        y_new = interp_y(t_new)
         # Look up uncertainties.
         interp_uy = interp1d(t, uy, **interp1d_params)
         uy_new = interp_uy(t_new)
     elif kind == "linear":
-        # Inter- or extrapolate values.
-        y_new = interp_y(t_new)
-
         # This following section is taken from scipy.interpolate.interp1d to
         # determine the indices of the relevant timestamps or frequencies.
         # ------------------------------------------------------------------------------

--- a/PyDynamic/uncertainty/interpolation.py
+++ b/PyDynamic/uncertainty/interpolation.py
@@ -52,7 +52,7 @@ def interp1d_unc(
             ascending order.
         y : (N,) array_like
             A 1-D array of real values. The length of y must be equal to the length
-            of t_new
+            of t
         uy : (N,) array_like
             A 1-D array of real values representing the uncertainties associated with y.
         kind : str, optional

--- a/PyDynamic/uncertainty/interpolation.py
+++ b/PyDynamic/uncertainty/interpolation.py
@@ -9,8 +9,7 @@ This module contains the following function:
 * :func:`interp1d_unc`: Interpolate arbitrary time series considering the associated
   uncertainties
 """
-
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 
 import numpy as np
 from scipy.interpolate import interp1d

--- a/PyDynamic/uncertainty/interpolation.py
+++ b/PyDynamic/uncertainty/interpolation.py
@@ -81,6 +81,9 @@ def interp1d_unc(
             If False, values of t can be in any order and they are sorted first. If
             True, t has to be an array of monotonically increasing values.
         return_c : bool, optional
+            This feature is not yet implemented, but will be provided in the near
+            future. Setting return_c to True thus results in an exception being
+            thrown for now.
             If True, return sensitivity coefficients for later use. If False
             sensitivity coefficients are not returned and internal computation is
             a little more efficient. Default is False.
@@ -177,11 +180,6 @@ def interp1d_unc(
                 "Unfortunately we did not yet implement this feature. It will be "
                 "present in the near future."
             )
-            # We return sensitivities as a matrix. We get it by writing out our
-            # equation to calculate the sensitivities as matrix equation. The
-            # sensitivities in the first place are:
-            # c_1 = (t_new - t_hi) / (t_hi - t_lo)
-            # c_2 = (t_new - t_lo) / (t_hi - t_lo)
 
         uy_new = np.sqrt(
             (t_new - t_hi) ** 2 * uy_prev_sqr + (t_new - t_lo) ** 2 * uy_next_sqr

--- a/PyDynamic/uncertainty/interpolation.py
+++ b/PyDynamic/uncertainty/interpolation.py
@@ -33,7 +33,7 @@ def interp1d_unc(
     r"""Interpolate a 1-D function considering the associated uncertainties
 
     t and y are arrays of values used to approximate some function :math:`f \colon y
-    = f(x)`.
+    = f(t)`.
 
     Note that calling :func:`interp1d_unc` with NaNs present in input values
     results in undefined behaviour.

--- a/PyDynamic/uncertainty/interpolation.py
+++ b/PyDynamic/uncertainty/interpolation.py
@@ -203,13 +203,13 @@ def interp1d_unc(
 
         # If interpolation is needed, compute uncertainties following White, 2017.
         if np.any(interpolation_range):
-            uy_prev_sqr = uy[lo] ** 2
-            uy_next_sqr = uy[hi] ** 2
+            uy_prev_sqr = uy[lo[interpolation_range]] ** 2
+            uy_next_sqr = uy[hi[interpolation_range]] ** 2
             uy_new[interpolation_range] = np.sqrt(
                 (t_new[interpolation_range] - t_hi[interpolation_range]) ** 2
-                * uy_prev_sqr[interpolation_range]
+                * uy_prev_sqr
                 + (t_new[interpolation_range] - t_lo[interpolation_range]) ** 2
-                * uy_next_sqr[interpolation_range]
+                * uy_next_sqr
             ) / (t_hi[interpolation_range] - t_lo[interpolation_range])
     else:
         raise NotImplementedError(

--- a/PyDynamic/uncertainty/interpolation.py
+++ b/PyDynamic/uncertainty/interpolation.py
@@ -103,7 +103,7 @@ def interp1d_unc(
     # ----------------------------------------------------------------------------------
     t = np.array(t, copy=copy)
     y = np.array(y, copy=copy)
-    uy = np.array(y, copy=copy)
+    uy = np.array(uy, copy=copy)
 
     if not assume_sorted:
         ind = np.argsort(t)

--- a/test/test_interpolation.py
+++ b/test/test_interpolation.py
@@ -45,7 +45,7 @@ def timestamps_values_uncertainties_kind(
         dt, kind for interp1d_unc()
     """
     # Set the maximum absolute value for floats to be really unique in calculations.
-    float_abs_max = 1e128
+    float_abs_max = 1e300
     # Set all common parameters for timestamps, measurements values and associated
     # uncertainties.
     shape_for_timestamps = hnp.array_shapes(

--- a/test/test_interpolation.py
+++ b/test/test_interpolation.py
@@ -54,7 +54,7 @@ def timestamps_values_uncertainties_kind(
         dt, kind for interp1d_unc()
     """
     # Set the maximum absolute value for floats to be really unique in calculations.
-    float_abs_max = 1e150
+    float_abs_max = 1e64
     # Set generic float parameters.
     float_generic_params = {
         "allow_nan": False,

--- a/test/test_interpolation.py
+++ b/test/test_interpolation.py
@@ -185,8 +185,8 @@ def test_trivial_in_interp1d_unc(interp_inputs):
 def test_linear_in_interp1d_unc(interp_inputs):
     y_new, uy_new = interp1d_unc(**interp_inputs)[1:3]
     # Check if all interpolated values lie in the range of the original values.
-    assert np.all(np.amin(interp_inputs["y"]) <= y_new)
-    assert np.all(np.amax(interp_inputs["y"]) >= y_new)
+    assert np.all(np.min(interp_inputs["y"]) <= y_new)
+    assert np.all(np.max(interp_inputs["y"]) >= y_new)
 
 
 @given(timestamps_values_uncertainties_kind(extrapolate=True))

--- a/test/test_interpolation.py
+++ b/test/test_interpolation.py
@@ -225,12 +225,13 @@ def test_extrapolate_interp1d_unc(interp_inputs):
 
 
 @given(
-    timestamps_values_uncertainties_kind(sorted_timestamps=True, extrapolate="below")
+    timestamps_values_uncertainties_kind(
+        sorted_timestamps=True, extrapolate="below", restrict_fill_value="str"
+    )
 )
 def test_extrapolate_below_without_fill_value_interp1d_unc(interp_inputs):
-    # Filter those cases where at least one of t_new is below the minimum of t and
+    # Deal with those cases where at least one of t_new is below the minimum of t and
     # fill_value=="extrapolate", which means constant extrapolation from the boundaries.
-    assume(isinstance(interp_inputs["fill_value"], str))
     y_new = interp1d_unc(**interp_inputs)[1]
     # Check that extrapolation works, meaning in the present case, that the boundary
     # value of y is taken for all t_new below the original bound.

--- a/test/test_interpolation.py
+++ b/test/test_interpolation.py
@@ -376,8 +376,7 @@ def test_linear_uy_in_interp1d_unc(n,):
 def test_wrong_input_lengths_call_interp1d(interp_inputs):
     # Check erroneous calls with unequally long inputs.
     with raises(ValueError):
-        interp_inputs["y"] = np.tile(interp_inputs["y"], 2)
-        interp_inputs["uy"] = np.tile(interp_inputs["uy"], 3)
+        interp_inputs["uy"] = np.tile(interp_inputs["uy"], 2)
         interp1d_unc(**interp_inputs)
 
 

--- a/test/test_interpolation.py
+++ b/test/test_interpolation.py
@@ -90,45 +90,10 @@ def test_usual_call(interp_inputs):
     assert len(t_new) == len(y_new) == len(uy_new)
 
 
-@given(timestamps_values_uncertainties_kind(min_count=1, max_count=1))
-def test_too_few_timestamps_call(interp_inputs):
-    # Check that too few timestamps raise exceptions.
-    with raises(ValueError):
-        interp1d_unc(**interp_inputs)
-
-
 @given(timestamps_values_uncertainties_kind())
 def test_wrong_input_length_y_call_interp1d_unc(interp_inputs):
     # Check erroneous calls with unequally long inputs.
     interp_inputs["y"] = np.tile(interp_inputs["y"], 2)
-    with raises(ValueError):
-        interp1d_unc(**interp_inputs)
-
-
-@given(timestamps_values_uncertainties_kind())
-def test_t_new_below_range_interp1d_unc(interp_inputs):
-    # Check erroneous calls with t_new's minimum below t's minimum. The complicated
-    # translation follows from covering all cases with very large values in and
-    # very large differences between t_new and t.
-    interp_inputs["t_new"] -= (
-        np.abs(np.amin(interp_inputs["t"]) - np.amin(interp_inputs["t_new"]))
-        + np.abs(np.amin(interp_inputs["t"]))
-        + 1
-    ) * 1.1
-    with raises(ValueError):
-        interp1d_unc(**interp_inputs)
-
-
-@given(timestamps_values_uncertainties_kind())
-def test_t_new_above_range_interp1d_unc(interp_inputs):
-    # Check erroneous calls with t_new's maximum above t's maximum. The complicated
-    # translation follows from covering all cases with very large values in and very
-    # large differences between t_new and t.
-    interp_inputs["t_new"] += (
-        np.abs(np.amax(interp_inputs["t"]) - np.amax(interp_inputs["t_new"]))
-        + np.abs(np.amax(interp_inputs["t"]))
-        + 1
-    ) * 1.1
     with raises(ValueError):
         interp1d_unc(**interp_inputs)
 

--- a/test/test_interpolation.py
+++ b/test/test_interpolation.py
@@ -167,17 +167,6 @@ def test_wrong_input_length_uy_call_interp1d_unc(interp_inputs):
         interp1d_unc(**interp_inputs)
 
 
-@given(timestamps_values_uncertainties_kind(sorted_timestamps=False))
-def test_wrong_input_order_call_interp1d_unc(interp_inputs):
-    # Ensure the timestamps are not in ascending order.
-    assume(not np.all(interp_inputs["t"][1:] >= interp_inputs["t"][:-1]))
-    # Check erroneous calls with descending timestamps.
-    interp_inputs["assume_sorted"] = True
-    with raises(ValueError):
-        # Reverse order of t and call interp1d_unc().
-        interp1d_unc(**interp_inputs)
-
-
 @given(timestamps_values_uncertainties_kind(kind_tuple=("previous", "next", "nearest")))
 def test_trivial_in_interp1d_unc(interp_inputs):
     y_new, uy_new = interp1d_unc(**interp_inputs)[1:3]

--- a/test/test_interpolation.py
+++ b/test/test_interpolation.py
@@ -214,9 +214,9 @@ def test_linear_uy_in_interp1d_unc(n,):
 def test_wrong_input_lengths_call_interp1d(interp_inputs):
     # Check erroneous calls with unequally long inputs.
     with raises(ValueError):
-        y_wrong = np.tile(interp_inputs["y"], 2)
-        uy_wrong = np.tile(interp_inputs["uy"], 3)
-        interp1d_unc(interp_inputs["t"], y_wrong, uy_wrong)
+        interp_inputs["y"] = np.tile(interp_inputs["y"], 2)
+        interp_inputs["uy"] = np.tile(interp_inputs["uy"], 3)
+        interp1d_unc(**interp_inputs)
 
 
 @given(

--- a/test/test_interpolation.py
+++ b/test/test_interpolation.py
@@ -54,7 +54,7 @@ def timestamps_values_uncertainties_kind(
         dt, kind for interp1d_unc()
     """
     # Set the maximum absolute value for floats to be really unique in calculations.
-    float_abs_max = 1e300
+    float_abs_max = 1e150
     # Set generic float parameters.
     float_generic_params = {
         "allow_nan": False,

--- a/test/test_interpolation.py
+++ b/test/test_interpolation.py
@@ -210,6 +210,15 @@ def test_linear_uy_in_interp1d_unc(n,):
     )
 
 
+@given(timestamps_values_uncertainties_kind())
+def test_wrong_input_lengths_call_interp1d(interp_inputs):
+    # Check erroneous calls with unequally long inputs.
+    with raises(ValueError):
+        y_wrong = np.tile(interp_inputs["y"], 2)
+        uy_wrong = np.tile(interp_inputs["uy"], 3)
+        interp1d_unc(interp_inputs["t"], y_wrong, uy_wrong)
+
+
 @given(
     timestamps_values_uncertainties_kind(
         kind_tuple=("spline", "lagrange", "least-squares")

--- a/test/test_interpolation.py
+++ b/test/test_interpolation.py
@@ -66,7 +66,8 @@ def timestamps_values_uncertainties_kind(
     t = draw(hnp.arrays(**strategy_params))
     # Sort timestamps in ascending order.
     if sorted_timestamps:
-        t.sort()
+        ind = np.argsort(t)
+        t = t[ind]
     # Reuse "original" timestamps shape for measurements values and associated
     # uncertainties and draw both.
     strategy_params["shape"] = np.shape(t)
@@ -80,7 +81,15 @@ def timestamps_values_uncertainties_kind(
     )
     t_new = draw(hnp.arrays(**strategy_params))
     kind = draw(st.sampled_from(kind_tuple))
-    return {"t_new": t_new, "t": t, "y": y, "uy": uy, "kind": kind}
+    assume_sorted = sorted_timestamps
+    return {
+        "t_new": t_new,
+        "t": t,
+        "y": y,
+        "uy": uy,
+        "kind": kind,
+        "assume_sorted": assume_sorted,
+    }
 
 
 @given(timestamps_values_uncertainties_kind())
@@ -111,6 +120,7 @@ def test_wrong_input_order_call_interp1d_unc(interp_inputs):
     # Ensure the timestamps are not in ascending order.
     assume(not np.all(interp_inputs["t"][1:] >= interp_inputs["t"][:-1]))
     # Check erroneous calls with descending timestamps.
+    interp_inputs["assume_sorted"] = True
     with raises(ValueError):
         # Reverse order of t and call interp1d_unc().
         interp1d_unc(**interp_inputs)

--- a/test/test_interpolation.py
+++ b/test/test_interpolation.py
@@ -19,29 +19,31 @@ def timestamps_values_uncertainties_kind(
     kind_tuple: Optional[Tuple[str]] = ("linear", "previous", "next", "nearest"),
     sorted_timestamps: Optional[bool] = True,
     extrapolate: Optional[Union[bool, str]] = False,
+    restrict_fill_value: Optional[str] = None,
+    restrict_fill_unc: Optional[str] = None,
 ) -> Dict[str, Union[np.ndarray, str]]:
     """Set custom strategy for _hypothesis_ to draw desired input from
 
     Parameters
     ----------
-        draw: callable
+        draw : callable
             this is a hypothesis internal callable to actually draw from provided
             strategies
-        min_count: int
+        min_count : int
             the minimum number of elements expected inside the arrays of timestamps
              (or frequencies), measurement values and associated uncertainties
-        max_count: int
+        max_count : int
             the maximum number of elements expected inside the arrays of timestamps
             (or frequencies), measurement values and associated uncertainties
-        kind_tuple: tuple(str), optional
+        kind_tuple : tuple(str), optional
             the tuple of strings out of "linear", "previous", "next", "nearest",
             "spline", "lagrange", "least-squares" from which the strategy for the
             kind randomly chooses. Defaults to the valid options "linear",
             "previous", "next", "nearest"
-        sorted_timestamps: bool
+        sorted_timestamps : bool
             if True the timestamps (or frequencies) are guaranteed to be in ascending
             order, if False they still might be by coincidence or not
-        extrapolate: bool or str, optional
+        extrapolate : bool or str, optional
             If True the interpolation timestamps (or frequencies) are generated such
             that extrapolation is necessary by guarantying at least one of the
             interpolation timestamps (or frequencies) outside the original bounds
@@ -49,12 +51,51 @@ def timestamps_values_uncertainties_kind(
             `bounds_error = False`. If False each element of t_new is guaranteed to
             lie within the range of t. Can be set to "above" or "below" to guarantee
             at least one element of t_new to lie either below or above the bounds of t.
+        restrict_fill_value : str, optional
+            String specifying the desired strategy for drawing a fill_value. One of
+            "float", "tuple", "str", "nan" to guarantee either a float, a tuple of
+            two floats, the string "extrapolate" or np.nan.
+        restrict_fill_unc : str, optional
+            Same as fill_value, but just for the uncertainties.
 
     Returns
     -------
-        A dict containing the randomly generated expected input parameters t, y, uy,
-        dt, kind for interp1d_unc()
+        A dict containing the randomly generated expected input parameters for
+        `interp1d_unc()`
     """
+
+    def draw_fill_values(strategy_spec: str):
+        """Little helper to find proper strategy for efficient testing.
+
+        Parameters
+        ----------
+            strategy_spec : str
+                String specifying the desired strategy for drawing a fill_value. One of
+                "float", "tuple", "str", "nan" to guarantee either a float, a tuple of
+                two floats, the string "extrapolate" or np.nan.
+
+        Returns
+        -------
+            The drawn sample to match desired fill_value.
+        """
+        float_strategy = st.floats(**float_generic_params)
+        tuple_strategy = st.tuples(float_strategy, float_strategy)
+        string_strategy = st.just("extrapolate")
+        nan_strategy = st.just(np.nan)
+        if strategy_spec == "float":
+            fill_strategy = float_strategy
+        elif strategy_spec == "tuple":
+            fill_strategy = tuple_strategy
+        elif strategy_spec == "str":
+            fill_strategy = string_strategy
+        elif strategy_spec == "nan":
+            fill_strategy = nan_strategy
+        else:
+            fill_strategy = st.one_of(
+                float_strategy, tuple_strategy, string_strategy, nan_strategy
+            )
+        return draw(fill_strategy)
+
     # Set the maximum absolute value for floats to be really unique in calculations.
     float_abs_max = 1e64
     # Set generic float parameters.
@@ -106,14 +147,8 @@ def timestamps_values_uncertainties_kind(
         # In case we want to extrapolate, draw some fill values for the
         # out-of-bounds range. Those will be either single floats or a 2-tuple of
         # floats or the special value "extrapolate".
-        float_strategy = st.floats(**float_generic_params)
-        fill_strategy = st.one_of(
-            float_strategy,
-            st.tuples(float_strategy, float_strategy),
-            st.just("extrapolate"),
-        )
-        fill_value = draw(fill_strategy)
-        fill_unc = draw(fill_strategy)
+        fill_value = draw_fill_values(restrict_fill_value)
+        fill_unc = draw_fill_values(restrict_fill_unc)
         bounds_error = False
 
     # Draw interpolation timestamps (or frequencies).
@@ -205,11 +240,14 @@ def test_extrapolate_below_without_fill_value_interp1d_unc(interp_inputs):
     )
 
 
-@given(timestamps_values_uncertainties_kind(extrapolate="below"))
+@given(
+    timestamps_values_uncertainties_kind(
+        extrapolate="below", restrict_fill_value="float"
+    )
+)
 def test_extrapolate_below_with_fill_value_interp1d_unc(interp_inputs):
-    # Filter those cases where at least one of t_new is below the minimum of t and
+    # Deal with those cases where at least one of t_new is below the minimum of t and
     # fill_value is a float, which means constant extrapolation with this value.
-    assume(isinstance(interp_inputs["fill_value"], float))
     y_new = interp1d_unc(**interp_inputs)[1]
     # Check that extrapolation works.
     assert np.all(
@@ -218,11 +256,14 @@ def test_extrapolate_below_with_fill_value_interp1d_unc(interp_inputs):
     )
 
 
-@given(timestamps_values_uncertainties_kind(extrapolate="below"))
+@given(
+    timestamps_values_uncertainties_kind(
+        extrapolate="below", restrict_fill_value="tuple"
+    )
+)
 def test_extrapolate_below_with_fill_values_interp1d_unc(interp_inputs):
-    # Filter those cases where at least one of t_new is below the minimum of t and
+    # Deal with those cases where at least one of t_new is below the minimum of t and
     # fill_value is a float, which means constant extrapolation with this value.
-    assume(isinstance(interp_inputs["fill_value"], tuple))
     y_new = interp1d_unc(**interp_inputs)[1]
     # Check that extrapolation works.
     assert np.all(
@@ -232,12 +273,13 @@ def test_extrapolate_below_with_fill_values_interp1d_unc(interp_inputs):
 
 
 @given(
-    timestamps_values_uncertainties_kind(sorted_timestamps=True, extrapolate="above")
+    timestamps_values_uncertainties_kind(
+        sorted_timestamps=True, extrapolate="above", restrict_fill_value="str"
+    )
 )
 def test_extrapolate_above_without_fill_value_interp1d_unc(interp_inputs):
-    # Filter those cases where at least one of t_new is above the maximum of t and
+    # Deal with those cases where at least one of t_new is above the maximum of t and
     # fill_value=="extrapolate", which means constant extrapolation from the boundaries.
-    assume(isinstance(interp_inputs["fill_value"], str))
     y_new = interp1d_unc(**interp_inputs)[1]
     # Check that extrapolation works, meaning in the present case, that the boundary
     # value of y is taken for all t_new above the original bound.
@@ -247,11 +289,14 @@ def test_extrapolate_above_without_fill_value_interp1d_unc(interp_inputs):
     )
 
 
-@given(timestamps_values_uncertainties_kind(extrapolate="above"))
+@given(
+    timestamps_values_uncertainties_kind(
+        extrapolate="above", restrict_fill_value="float"
+    )
+)
 def test_extrapolate_above_with_fill_value_interp1d_unc(interp_inputs):
-    # Filter those cases where at least one of t_new is above the maximum of t and
+    # Deal with those cases where at least one of t_new is above the maximum of t and
     # fill_value is a float, which means constant extrapolation with this value.
-    assume(isinstance(interp_inputs["fill_value"], float))
     y_new = interp1d_unc(**interp_inputs)[1]
     # Check that extrapolation works.
     assert np.all(
@@ -260,11 +305,14 @@ def test_extrapolate_above_with_fill_value_interp1d_unc(interp_inputs):
     )
 
 
-@given(timestamps_values_uncertainties_kind(extrapolate="above"))
+@given(
+    timestamps_values_uncertainties_kind(
+        extrapolate="above", restrict_fill_value="tuple"
+    )
+)
 def test_extrapolate_above_with_fill_values_interp1d_unc(interp_inputs):
-    # Filter those cases where at least one of t_new is above the maximum of t and
+    # Deal with those cases where at least one of t_new is above the maximum of t and
     # fill_value is a float, which means constant extrapolation with this value.
-    assume(isinstance(interp_inputs["fill_value"], tuple))
     y_new = interp1d_unc(**interp_inputs)[1]
     # Check that extrapolation works.
     assert np.all(
@@ -274,12 +322,13 @@ def test_extrapolate_above_with_fill_values_interp1d_unc(interp_inputs):
 
 
 @given(
-    timestamps_values_uncertainties_kind(sorted_timestamps=True, extrapolate="below")
+    timestamps_values_uncertainties_kind(
+        sorted_timestamps=True, extrapolate="below", restrict_fill_unc="str"
+    )
 )
 def test_extrapolate_below_without_fill_unc_interp1d_unc(interp_inputs):
-    # Filter those cases where at least one of t_new is below the minimum of t and
+    # Deal with those cases where at least one of t_new is below the minimum of t and
     # fill_unc=="extrapolate", which means constant extrapolation from the boundaries.
-    assume(isinstance(interp_inputs["fill_unc"], str))
     uy_new = interp1d_unc(**interp_inputs)[2]
     # Check that extrapolation works, meaning in the present case, that the boundary
     # value of y is taken for all t_new below the original bound.
@@ -289,11 +338,12 @@ def test_extrapolate_below_without_fill_unc_interp1d_unc(interp_inputs):
     )
 
 
-@given(timestamps_values_uncertainties_kind(extrapolate="below"))
+@given(
+    timestamps_values_uncertainties_kind(extrapolate="below", restrict_fill_unc="float")
+)
 def test_extrapolate_below_with_fill_unc_interp1d_unc(interp_inputs):
-    # Filter those cases where at least one of t_new is below the minimum of t and
+    # Deal with those cases where at least one of t_new is below the minimum of t and
     # fill_unc is a float, which means constant extrapolation with this value.
-    assume(isinstance(interp_inputs["fill_unc"], float))
     uy_new = interp1d_unc(**interp_inputs)[2]
     # Check that extrapolation works.
     assert np.all(
@@ -302,10 +352,12 @@ def test_extrapolate_below_with_fill_unc_interp1d_unc(interp_inputs):
     )
 
 
-@given(timestamps_values_uncertainties_kind(extrapolate="below"))
+@given(
+    timestamps_values_uncertainties_kind(extrapolate="below", restrict_fill_unc="tuple")
+)
 def test_extrapolate_below_with_fill_uncs_interp1d_unc(interp_inputs):
-    # Filter those cases where at least one of t_new is below the minimum of t and
-    # fill_unc is a float, which means constant extrapolation with this value.
+    # Deal with those cases where at least one of t_new is below the minimum of t and
+    # fill_unc is a tuple, which means constant extrapolation with its first element.
     assume(isinstance(interp_inputs["fill_unc"], tuple))
     uy_new = interp1d_unc(**interp_inputs)[2]
     # Check that extrapolation works.
@@ -316,12 +368,13 @@ def test_extrapolate_below_with_fill_uncs_interp1d_unc(interp_inputs):
 
 
 @given(
-    timestamps_values_uncertainties_kind(sorted_timestamps=True, extrapolate="above")
+    timestamps_values_uncertainties_kind(
+        sorted_timestamps=True, extrapolate="above", restrict_fill_unc="str"
+    )
 )
 def test_extrapolate_above_without_fill_unc_interp1d_unc(interp_inputs):
-    # Filter those cases where at least one of t_new is above the maximum of t and
+    # Deal with those cases where at least one of t_new is above the maximum of t and
     # fill_unc=="extrapolate", which means constant extrapolation from the boundaries.
-    assume(isinstance(interp_inputs["fill_unc"], str))
     uy_new = interp1d_unc(**interp_inputs)[2]
     # Check that extrapolation works, meaning in the present case, that the boundary
     # value of y is taken for all t_new above the original bound.
@@ -331,11 +384,12 @@ def test_extrapolate_above_without_fill_unc_interp1d_unc(interp_inputs):
     )
 
 
-@given(timestamps_values_uncertainties_kind(extrapolate="above"))
+@given(
+    timestamps_values_uncertainties_kind(extrapolate="above", restrict_fill_unc="float")
+)
 def test_extrapolate_above_with_fill_unc_interp1d_unc(interp_inputs):
-    # Filter those cases where at least one of t_new is above the maximum of t and
+    # Deal with those cases where at least one of t_new is above the maximum of t and
     # fill_unc is a float, which means constant extrapolation with this value.
-    assume(isinstance(interp_inputs["fill_unc"], float))
     uy_new = interp1d_unc(**interp_inputs)[2]
     # Check that extrapolation works.
     assert np.all(
@@ -344,11 +398,12 @@ def test_extrapolate_above_with_fill_unc_interp1d_unc(interp_inputs):
     )
 
 
-@given(timestamps_values_uncertainties_kind(extrapolate="above"))
+@given(
+    timestamps_values_uncertainties_kind(extrapolate="above", restrict_fill_unc="tuple")
+)
 def test_extrapolate_above_with_fill_uncs_interp1d_unc(interp_inputs):
-    # Filter those cases where at least one of t_new is above the maximum of t and
-    # fill_unc is a float, which means constant extrapolation with this value.
-    assume(isinstance(interp_inputs["fill_unc"], tuple))
+    # Deal with those cases where at least one of t_new is above the maximum of t and
+    # fill_unc is a tuple, which means constant extrapolation with its second element.
     uy_new = interp1d_unc(**interp_inputs)[2]
     # Check that extrapolation works.
     assert np.all(

--- a/test/test_interpolation.py
+++ b/test/test_interpolation.py
@@ -109,7 +109,7 @@ def timestamps_values_uncertainties_kind(
         float_strategy = st.floats(**float_generic_params)
         fill_strategy = st.one_of(
             float_strategy,
-            st.tuples(*tuple(itertools.repeat(st.floats(**float_generic_params), 2))),
+            st.tuples(float_strategy, float_strategy),
             st.just("extrapolate"),
         )
         fill_value = draw(fill_strategy)

--- a/test/test_make_equidistant.py
+++ b/test/test_make_equidistant.py
@@ -5,7 +5,7 @@ from typing import Dict, Optional, Tuple, Union
 import hypothesis.extra.numpy as hnp
 import hypothesis.strategies as st
 import numpy as np
-from hypothesis import assume, example, given
+from hypothesis import given
 from hypothesis.strategies import composite
 from pytest import raises
 
@@ -96,18 +96,6 @@ def test_too_short_call_make_equidistant(interp_inputs):
         make_equidistant(interp_inputs["t"], interp_inputs["y"])
 
 
-from numpy import array
-
-
-@example(
-    {
-        "dt": 1.1417981541647915e46,
-        "kind": "linear",
-        "t": array([1.973629e62, 1.973629e62]),
-        "uy": array([0.00000000e00, 2.22044605e48]),
-        "y": array([0.00000000e00, 2.22044605e48]),
-    },
-)
 @given(timestamps_values_uncertainties_kind())
 def test_full_call_make_equidistant(interp_inputs):
     t_new, y_new, uy_new = make_equidistant(**interp_inputs)

--- a/test/test_make_equidistant.py
+++ b/test/test_make_equidistant.py
@@ -112,16 +112,6 @@ def test_wrong_input_lengths_call_make_equidistant(interp_inputs):
         make_equidistant(interp_inputs["t"], y_wrong, uy_wrong)
 
 
-@given(timestamps_values_uncertainties_kind(sorted_timestamps=False))
-def test_wrong_input_order_call_make_equidistant(interp_inputs):
-    # Ensure the timestamps are not in ascending order.
-    assume(not np.all(interp_inputs["t"][1:] >= interp_inputs["t"][:-1]))
-    # Check erroneous calls with descending timestamps.
-    with raises(ValueError):
-        # Reverse order of t and call make_equidistant().
-        make_equidistant(**interp_inputs)
-
-
 @given(timestamps_values_uncertainties_kind())
 def test_t_new_to_dt_make_equidistant(interp_inputs):
     t_new = make_equidistant(**interp_inputs)[0]

--- a/test/test_make_equidistant.py
+++ b/test/test_make_equidistant.py
@@ -47,7 +47,7 @@ def timestamps_values_uncertainties_kind(
         dt, kind for make_equidistant()
     """
     # Set the maximum absolute value for floats to be really unique in calculations.
-    float_abs_max = 1e300
+    float_abs_max = 1e64
     # Set all common parameters for timestamps, measurements values and associated
     # uncertainties including allowed ranges and number of elements.
     shape_for_timestamps = hnp.array_shapes(

--- a/test/test_make_equidistant.py
+++ b/test/test_make_equidistant.py
@@ -5,7 +5,7 @@ from typing import Dict, Optional, Tuple, Union
 import hypothesis.extra.numpy as hnp
 import hypothesis.strategies as st
 import numpy as np
-from hypothesis import assume, given
+from hypothesis import assume, example, given
 from hypothesis.strategies import composite
 from pytest import raises
 
@@ -77,7 +77,7 @@ def timestamps_values_uncertainties_kind(
     dt = draw(
         st.floats(
             min_value=(np.max(t) - np.min(t)) * 1e-3,
-            max_value=np.max(t) - np.min(t),
+            max_value=(np.max(t) - np.min(t)) / 2,
             exclude_min=True,
             allow_nan=False,
             allow_infinity=False,
@@ -96,6 +96,18 @@ def test_too_short_call_make_equidistant(interp_inputs):
         make_equidistant(interp_inputs["t"], interp_inputs["y"])
 
 
+from numpy import array
+
+
+@example(
+    {
+        "dt": 1.1417981541647915e46,
+        "kind": "linear",
+        "t": array([1.973629e62, 1.973629e62]),
+        "uy": array([0.00000000e00, 2.22044605e48]),
+        "y": array([0.00000000e00, 2.22044605e48]),
+    },
+)
 @given(timestamps_values_uncertainties_kind())
 def test_full_call_make_equidistant(interp_inputs):
     t_new, y_new, uy_new = make_equidistant(**interp_inputs)

--- a/test/test_make_equidistant.py
+++ b/test/test_make_equidistant.py
@@ -47,7 +47,7 @@ def timestamps_values_uncertainties_kind(
         dt, kind for make_equidistant()
     """
     # Set the maximum absolute value for floats to be really unique in calculations.
-    float_abs_max = 1e128
+    float_abs_max = 1e300
     # Set all common parameters for timestamps, measurements values and associated
     # uncertainties including allowed ranges and number of elements.
     shape_for_timestamps = hnp.array_shapes(


### PR DESCRIPTION
We finally add extrapolation based on the according SciPy feature to `interp1d_unc()` and reformulate documentation a little more generic to cover more use cases, in which the method is actually already applicable. This will resolve #110 .