### PR TITLE
Fix errors in make_equidistant() in floating point overflow situations

### DIFF
--- a/test/test_interpolation.py
+++ b/test/test_interpolation.py
@@ -1,4 +1,3 @@
-import itertools
 from typing import Dict, Optional, Tuple, Union
 
 import hypothesis.extra.numpy as hnp


### PR DESCRIPTION
Because of a certain rule of the numpy method [`arange`](https://numpy.org/doc/1.18/reference/generated/numpy.arange.html), which we use to build the array of interpolation nodes, it is not guaranteed, that the the last node is actually inside the desired range (see the linked docstring of the return value), which causes an exception in the interpolation step. This should be expected behaviour regarding the exception, but should not occur in real life when someone calls our method. We fix this by checking for this situation and removing the last node if needed. At the same time we remove the arbitrary constraint on the original timestamps being sorted in ascending order.