### PR TITLE
Actually fix the error in make_equidistant()

### DIFF
--- a/PyDynamic/misc/tools.py
+++ b/PyDynamic/misc/tools.py
@@ -244,11 +244,11 @@ def make_equidistant(t, y, uy, dt=5e-2, kind="linear"):
     # Setup new vector of timestamps.
     t_new = np.arange(np.min(t), np.max(t), dt)
 
-    # Since np.arange in overflow situations results in the last value not guaranteed to
-    # be smaller than t's maximum', we need to check for this and delete this
-    # unexpected value.
+    # Since np.arange in overflow situations results in the biggest values not
+    # guaranteed to be smaller than t's maximum', we need to check for this and delete
+    # these unexpected values.
     if t_new[-1] > np.max(t):
-        t_new = t_new[:-1]
+        t_new = t_new[t_new <= np.max(t)]
 
     return interp1d_unc(t_new, t, y, uy, kind)
 

--- a/PyDynamic/misc/tools.py
+++ b/PyDynamic/misc/tools.py
@@ -240,15 +240,18 @@ def make_equidistant(t, y, uy, dt=5e-2, kind="linear"):
         * White [White2017]_
     """
     from ..uncertainty.interpolation import interp1d_unc
+    
+    # Find t's maximum.
+    t_max = np.max(t)
 
     # Setup new vector of timestamps.
-    t_new = np.arange(np.min(t), np.max(t), dt)
+    t_new = np.arange(np.min(t), t_max, dt)
 
     # Since np.arange in overflow situations results in the biggest values not
     # guaranteed to be smaller than t's maximum', we need to check for this and delete
     # these unexpected values.
-    if t_new[-1] > np.max(t):
-        t_new = t_new[t_new <= np.max(t)]
+    if t_new[-1] > t_max:
+        t_new = t_new[t_new <= t_max]
 
     return interp1d_unc(t_new, t, y, uy, kind)
 


### PR DESCRIPTION
The previously fixed error in #128 was not only limited to one value in the provided list of equidistant interpolation timestamps but could spread over several of them. So we need to actually remove all of those.