### PR TITLE
Enhance setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,16 @@ us know. You may, for instance, drop an email to one of the [authors
 ](mailto:bjoern.ludwig@ptb.de) or [Maximilian Gruber
 ](mailto:maximilian.gruber@ptb.de))
 
+### Optional Jupyter Notebook dependencies
+
+If you are familiar with Jupyter Notebooks, you find some examples in the _examples_ and
+the _tutorials_ subfolders of the source code repository. To execute these you need
+additional dependencies which you can install via
+
+```shell
+pip install PyDynamic[examples]
+```
+
 ### Examples
 
 Uncertainty propagation for the application of a FIR filter with coefficients

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Install PyDynamic in Python path.
-"""
+"""Install PyDynamic in Python path and provide all packaging metadata."""
 
 from os import path
 
@@ -19,23 +17,29 @@ def get_readme():
 
 
 setup(
+    metadata_version="2.1",
     name="PyDynamic",
     version=VERSION,
     description="A software package for the analysis of dynamic measurements",
     long_description=get_readme(),
     long_description_content_type="text/markdown",
     url="https://ptb-pst1.github.io/PyDynamic/",
+    download_url="https://github.com/PTB-PSt1/PyDynamic/releases/download/v{0}/"
+    "PyDynamic-{0}.tar.gz".format(VERSION),
     author=u"Sascha Eichstädt, Maximilian Gruber, Björn Ludwig, Thomas Bruns, "
-    u"Ian Smith",
+    "Martin Weber",
     author_email="sascha.eichstaedt@ptb.de",
     keywords="uncertainty dynamic deconvolution metrology",
     packages=find_packages(exclude=["test"]),
     project_urls={
-        "Documentation": "https://pydynamic.readthedocs.io/",
-        "Source": "https://github.com/PTB-PSt1/PyDynamic/",
+        "Documentation": "https://pydynamic.readthedocs.io/en/v{}/".format(VERSION),
+        "Source": "https://github.com/PTB-PSt1/PyDynamic/tree/v{}/".format(VERSION),
         "Tracker": "https://github.com/PTB-PSt1/PyDynamic/issues",
     },
-    install_requires=["ipykernel", "matplotlib", "numpy", "pandas", "scipy", "sympy"],
+    install_requires=["matplotlib", "numpy", "pandas", "scipy"],
+    # This allow to do "pip install PyDynamic[examples]" and get the dependencies to
+    # execute the Jupyter Notebook examples.
+    extras_require={"examples": ["notebook"],},
     python_requires=">=3.5",
     classifiers=[
         "Development Status :: 4 - Beta",
@@ -51,6 +55,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Operating System :: OS Independent",
         "Typing :: Typed",
     ],
 )


### PR DESCRIPTION
We transform _notebook_ into an optional dependency and improve the links in the setup.py, which leads to the linked layout, of [the sidebar on pypi.org](https://test.pypi.org/project/PyDynamic/) with version specific links to

- the repo download,
- the source code,
- the documentation.

We base this on introduce model_estimation, because we as well add a hint about the optional dependencies to the README, which is only valid after the next release.