### PR TITLE
Extend interpolation test suite and fix bug

### DIFF
--- a/PyDynamic/uncertainty/interpolate.py
+++ b/PyDynamic/uncertainty/interpolate.py
@@ -169,7 +169,7 @@ def interp1d_unc(
 
         if fill_unc == "extrapolate":
             fill_unc = uy[0], uy[-1]
-        elif returnC:
+        elif bounds_error is not None and returnC:
             # Once we deal with this, we will probably introduce another input parameter
             # fill_sens which is expected to be of shape (N,) or a 2-tuple of this
             # shape, which is then used in C wherever an extrapolation is performed.

--- a/PyDynamic/uncertainty/interpolate.py
+++ b/PyDynamic/uncertainty/interpolate.py
@@ -170,7 +170,12 @@ def interp1d_unc(
         if fill_unc == "extrapolate":
             fill_unc = uy[0], uy[-1]
         elif bounds_error is not None and returnC:
-            # Once we deal with this, we will probably introduce another input parameter
+            # This means bounds_error is intentionally set to False and we want to
+            # extrapolate uncertainties with custom values. Additionally the sensitivity
+            # coefficients shall be returned. This is not yet possible, because in this
+            # case, we do not know, how to map the provided extrapolation values onto
+            # the original values and thus we cannot provide the coefficients. Once we
+            # deal with this, we will probably introduce another input parameter
             # fill_sens which is expected to be of shape (N,) or a 2-tuple of this
             # shape, which is then used in C wherever an extrapolation is performed.
             raise NotImplementedError(

--- a/test/test_interpolate.py
+++ b/test/test_interpolate.py
@@ -169,7 +169,9 @@ def timestamps_values_uncertainties_kind(
                 min_value=t_min, max_value=t_max, **float_generic_params
             )
             fill_value = fill_unc = np.nan
-            bounds_error = True
+            # Switch between default value None and intentionally setting to True,
+            # which should behave identical.
+            bounds_error = draw(st.one_of(st.just(True), st.none()))
         else:
             # In case we want to extrapolate, draw some fill values for the
             # out-of-bounds range. Those will be either single floats or a 2-tuple of
@@ -445,6 +447,7 @@ def test_extrapolate_above_with_fill_uncs_interp1d_unc(interp_inputs):
 def test_compare_returnc_interp1d_unc(interp_inputs):
     # Compare the uncertainties computed from the sensitivities inside the
     # interpolation range and directly.
+    assume(interp_inputs["bounds_error"] is None)
     uy_new_with_sensitivities = interp1d_unc(**interp_inputs)[2]
     interp_inputs["returnC"] = False
     uy_new_without_sensitivities = interp1d_unc(**interp_inputs)[2]

--- a/test/test_interpolate.py
+++ b/test/test_interpolate.py
@@ -447,7 +447,6 @@ def test_extrapolate_above_with_fill_uncs_interp1d_unc(interp_inputs):
 def test_compare_returnc_interp1d_unc(interp_inputs):
     # Compare the uncertainties computed from the sensitivities inside the
     # interpolation range and directly.
-    assume(interp_inputs["bounds_error"] is None)
     uy_new_with_sensitivities = interp1d_unc(**interp_inputs)[2]
     interp_inputs["returnC"] = False
     uy_new_without_sensitivities = interp1d_unc(**interp_inputs)[2]


### PR DESCRIPTION
This introduces the fix for an important corner case of parameter selection, in which we reveive a `NotImplementedError`, which is not true. The according call would be:

```python
interp1d_unc(t_new, t=t, y=y, uy=uy, returnC=True)
```

The cause of this is treating `bounds_error`'s default value `None` like an intentional `False`. In this PR we [correct the according Hypothesis strategy to cover these cases](8118f8b3bd6fe783eb5973f5b8789f1840943310) and [fail as expected](https://app.circleci.com/pipelines/github/PTB-PSt1/PyDynamic/844/workflows/b34a1aa3-1cc9-4fd1-8942-578ba297a16e) with the original implementation. Then we [adapt the implementation and fix the bug](https://github.com/PTB-PSt1/PyDynamic/pull/168/files/8118f8b3bd6fe783eb5973f5b8789f1840943310..ae382167a3ebc64e9a9a2b685d3e54c4efd4ed60) so [the tests pass](https://app.circleci.com/pipelines/github/PTB-PSt1/PyDynamic/847/workflows/b21c4c57-14ef-46af-805c-1e4c9b75d7b2) again.