### PR TITLE
Upgrade python-semantic-release options to latest release

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,8 @@ branch=master
 hvcs=github
 # Whether or not to commit changes when bumping version.
 commit_version_number=true
-changelog_file=CHANGELOG.md
+# The name of the file where the changelog is kept, relative to the root of the repo.
+changelog_file=docs/CHANGELOG.md
 # Comma-separated list of sections to display in the changelog. They will be
 # displayed in the order they are given. The available options depend on the commit
 # parser used.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,12 +1,32 @@
 [semantic_release]
-version_variable=PyDynamic/__init__.py:__version__
-version_source=commit
+# The file(s) and variable name of where the version number is stored.
+version_variable = PyDynamic/__init__.py:__version__,docs/conf.py:version
+# The way we get and set the new version. Can be commit or tag.
+# If set to tag, will get the current version from the latest tag matching vX.Y.Z.
+# This won’t change the source defined in version_variable.
+# If set to commit, will get the current version from the source defined in
+# version_variable, edit the file and commit it.
+version_source = commit
+# Import path of a Python function that can parse commit messages and return
+# information about the commit.
+commit_parser = semantic_release.history.angular_parser
+# If set to false the pypi uploading will be disabled.
 upload_to_pypi=true
+# If set to false, do not upload distributions to GitHub releases.
 upload_to_release=true
+# The branch to run releases from.
 branch=master
+# The name of your hvcs. Currently only GitHub and GitLab are supported.
 hvcs=github
+# Whether or not to commit changes when bumping version.
 commit_version_number=true
-compare_link=true
+changelog_file=CHANGELOG.md
+# Comma-separated list of sections to display in the changelog. They will be
+# displayed in the order they are given. The available options depend on the commit
+# parser used.
+changelog_sections = feature,fix,breaking,documentation,performance
+# A comma-separated list of the import paths of components to include in the changelog.
+changelog_components = semantic_release.changelog.changelog_headers,semantic_release.changelog.compare_url
 
 [rstcheck]
 ignore_messages=(No directive entry for "automodule" in module "docutils.parsers.rst.languages.en"\.$)


### PR DESCRIPTION
_python-semantic-release_ supports some more options by now, like creating or updateing a _CHANGELOG.md_ file (which we put in our _docs_ folder) and some more customizations. This PR updates our settings.