### PR TITLE
feat(tools) Added a method to shift a vector with associated uncertainty

### DIFF
--- a/PyDynamic/misc/tools.py
+++ b/PyDynamic/misc/tools.py
@@ -65,8 +65,7 @@ def shift_uncertainty(x, ux, shift):
             return xs, np.roll(ux, shift)
         elif len(ux.shape) == 2:      # full covariance matrix
             assert(ux.shape[0]==ux.shape[1])
-            uxs = np.roll(ux, shift, axis=0)
-            uxs = np.roll(uxs, shift, axis=1)
+            uxs = np.roll(ux, (shift, shift), axis=(0,1))
             return xs, uxs
         else:
             raise TypeError("Input uncertainty has incompatible shape")

--- a/PyDynamic/misc/tools.py
+++ b/PyDynamic/misc/tools.py
@@ -31,8 +31,45 @@ __all__ = [
     "make_equidistant",
     "trimOrPad",
     "progress_bar",
+    "shift_uncertainty"
 ]
 
+def shift_uncertainty(x, ux, shift):
+    """Shift the elements in the vector x (and associated uncertainty ux) by shift elements
+
+    Parameters
+    ----------
+        x: (N,) array_like
+            vector of estimates
+        ux: float, np.ndarray of shape (N,) or of shape (N,N)
+            uncertainty associated with the vector of estimates
+        shift: int
+            amount of shift
+
+    Returns
+    -------
+        np.ndarray of shape (N,)
+            shifted x and shifted ux of same type as original
+    """
+
+    assert(isinstance(shift, int))
+    # application of shift to the vector of estimates
+    xs = np.roll(x, shift)
+
+    if isinstance(ux, float):       # no shift necessary for ux
+        return xs, ux
+    if isinstance(ux, np.ndarray):
+        if len(ux.shape) == 1:      # uncertainties given as vector
+            xs, np.roll(ux, shift)
+        if len(ux.shape) == 2:      # full covariance matrix
+            assert(ux.shape[0]==ux.shape[1])
+            uxs = np.roll(ux, shift, axis=0)
+            uxs = np.roll(uxs, shift, axis=1)
+            return xs, uxs
+        else:
+            raise TypeError("Input uncertainty has incompatible type")
+    else:
+        raise TypeError("Input uncertainty has incompatible type")
 
 def trimOrPad(array, length, mode="constant"):
     """Trim or pad (with zeros) a vector to desired length"""

--- a/PyDynamic/misc/tools.py
+++ b/PyDynamic/misc/tools.py
@@ -69,7 +69,7 @@ def shift_uncertainty(x, ux, shift):
             uxs = np.roll(uxs, shift, axis=1)
             return xs, uxs
         else:
-            raise TypeError("Input uncertainty has incompatible type")
+            raise TypeError("Input uncertainty has incompatible shape")
     else:
         raise TypeError("Input uncertainty has incompatible type")
 

--- a/PyDynamic/misc/tools.py
+++ b/PyDynamic/misc/tools.py
@@ -35,7 +35,8 @@ __all__ = [
 ]
 
 def shift_uncertainty(x, ux, shift):
-    """Shift the elements in the vector x (and associated uncertainty ux) by shift elements
+    """Shift the elements in the vector x (and associated uncertainty ux) by shift elements.
+        This method uses :class:`numpy.roll` to shift the elements in x and ux. See documentation of np.roll for details.
 
     Parameters
     ----------

--- a/PyDynamic/misc/tools.py
+++ b/PyDynamic/misc/tools.py
@@ -60,7 +60,7 @@ def shift_uncertainty(x, ux, shift):
         return xs, ux
     if isinstance(ux, np.ndarray):
         if len(ux.shape) == 1:      # uncertainties given as vector
-            xs, np.roll(ux, shift)
+            return xs, np.roll(ux, shift)
         if len(ux.shape) == 2:      # full covariance matrix
             assert(ux.shape[0]==ux.shape[1])
             uxs = np.roll(ux, shift, axis=0)

--- a/PyDynamic/misc/tools.py
+++ b/PyDynamic/misc/tools.py
@@ -61,7 +61,7 @@ def shift_uncertainty(x, ux, shift):
     if isinstance(ux, np.ndarray):
         if len(ux.shape) == 1:      # uncertainties given as vector
             return xs, np.roll(ux, shift)
-        if len(ux.shape) == 2:      # full covariance matrix
+        elif len(ux.shape) == 2:      # full covariance matrix
             assert(ux.shape[0]==ux.shape[1])
             uxs = np.roll(ux, shift, axis=0)
             uxs = np.roll(uxs, shift, axis=1)

--- a/PyDynamic/misc/tools.py
+++ b/PyDynamic/misc/tools.py
@@ -48,8 +48,10 @@ def shift_uncertainty(x, ux, shift):
 
     Returns
     -------
-        np.ndarray of shape (N,)
-            shifted x and shifted ux of same type as original
+        xs: (N,) array
+            shifted vector of estimates
+        uxs: float, np.ndarray of shape (N,) or of shape (N,N)
+            uncertainty associated with the shifted vector of estimates
     """
 
     assert(isinstance(shift, int))


### PR DESCRIPTION
This method allows to apply a shift (such as a time delay) to a vector and its associated uncertainty.