### PR TITLE
fix(propagate_filter): insert assertion that sigma_noise must be 1D

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,9 +18,7 @@ pytest.xml
 # Jupyter Notebook artifacts #
 ##############################
 .ipynb_checkpoints/
-.idea/workspace.xml
-.idea/inspectionProfiles/profiles_settings.xml
-.idea/misc.xml
-.idea/modules.xml
-.idea/PyDynamic.iml
-.idea/vcs.xml
+
+# Environment artifacts #
+#########################
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,9 @@ pytest.xml
 # Jupyter Notebook artifacts #
 ##############################
 .ipynb_checkpoints/
+.idea/workspace.xml
+.idea/inspectionProfiles/profiles_settings.xml
+.idea/misc.xml
+.idea/modules.xml
+.idea/PyDynamic.iml
+.idea/vcs.xml

--- a/PyDynamic/uncertainty/propagate_filter.py
+++ b/PyDynamic/uncertainty/propagate_filter.py
@@ -25,6 +25,7 @@ __all__ = ["FIRuncFilter", "IIRuncFilter"]
 
 def FIRuncFilter(y, sigma_noise, theta, Utheta=None, shift=0, blow=None, kind="corr"):
     """Uncertainty propagation for signal y and uncertain FIR filter theta
+
     A preceding FIR low-pass filter with coefficients `blow` can be provided optionally.
 
     Parameters

--- a/PyDynamic/uncertainty/propagate_filter.py
+++ b/PyDynamic/uncertainty/propagate_filter.py
@@ -25,7 +25,7 @@ __all__ = ["FIRuncFilter", "IIRuncFilter"]
 
 def FIRuncFilter(y, sigma_noise, theta, Utheta=None, shift=0, blow=None, kind="corr"):
     """Uncertainty propagation for signal y and uncertain FIR filter theta
-    An optional FIR low-pass filter with coefficients blow can be provided optionally.
+    A preceding FIR low-pass filter with coefficients `blow` can be provided optionally.
 
     Parameters
     ----------

--- a/PyDynamic/uncertainty/propagate_filter.py
+++ b/PyDynamic/uncertainty/propagate_filter.py
@@ -25,6 +25,7 @@ __all__ = ["FIRuncFilter", "IIRuncFilter"]
 
 def FIRuncFilter(y, sigma_noise, theta, Utheta=None, shift=0, blow=None, kind="corr"):
     """Uncertainty propagation for signal y and uncertain FIR filter theta
+    An optional FIR low-pass filter with coefficients blow can be provided optionally.
 
     Parameters
     ----------
@@ -42,16 +43,16 @@ def FIRuncFilter(y, sigma_noise, theta, Utheta=None, shift=0, blow=None, kind="c
         blow: np.ndarray
             optional FIR low-pass filter
         kind: string
-            only meaningfull in combination with isinstance(sigma_noise, numpy.ndarray)
+            only meaningfull in combination with sigma_noise a 1D numpy array
             "diag": point-wise standard uncertainties of non-stationary white noise
-            "corr": single sided autocovariance of stationary (colored/corrlated) noise (default)
+            "corr": single sided autocovariance of stationary (colored/correlated) noise (default)
 
     Returns
     -------
         x: np.ndarray
             FIR filter output signal
         ux: np.ndarray
-            point-wise uncertainties associated with x
+            point-wise standard uncertainties associated with x
 
 
     References
@@ -63,7 +64,6 @@ def FIRuncFilter(y, sigma_noise, theta, Utheta=None, shift=0, blow=None, kind="c
     """
 
     Ntheta = len(theta)  # FIR filter size
-    # filterOrder = Ntheta - 1   # FIR filter order
 
     if not isinstance(Utheta, np.ndarray):  # handle case of zero uncertainty filter
         Utheta = np.zeros((Ntheta, Ntheta))
@@ -73,6 +73,7 @@ def FIRuncFilter(y, sigma_noise, theta, Utheta=None, shift=0, blow=None, kind="c
         sigma2 = sigma_noise ** 2
 
     elif isinstance(sigma_noise, np.ndarray):
+        assert (len(sigma_noise.shape)==1), "FIRuncFilter: Uncertainty associated with input signal must be a 1D array"
         if kind == "diag":
             sigma2 = sigma_noise ** 2
         elif kind == "corr":

--- a/PyDynamic/uncertainty/propagate_filter.py
+++ b/PyDynamic/uncertainty/propagate_filter.py
@@ -43,9 +43,10 @@ def FIRuncFilter(y, sigma_noise, theta, Utheta=None, shift=0, blow=None, kind="c
         blow: np.ndarray
             optional FIR low-pass filter
         kind: string
-            only meaningfull in combination with sigma_noise a 1D numpy array
+            only meaningful in combination with sigma_noise a 1D numpy array
             "diag": point-wise standard uncertainties of non-stationary white noise
-            "corr": single sided autocovariance of stationary (colored/correlated) noise (default)
+            "corr": single sided autocovariance of stationary (colored/correlated)
+                    noise (default)
 
     Returns
     -------

--- a/PyDynamic/uncertainty/propagate_filter.py
+++ b/PyDynamic/uncertainty/propagate_filter.py
@@ -72,8 +72,7 @@ def FIRuncFilter(y, sigma_noise, theta, Utheta=None, shift=0, blow=None, kind="c
     if isinstance(sigma_noise, float):
         sigma2 = sigma_noise ** 2
 
-    elif isinstance(sigma_noise, np.ndarray):
-        assert (len(sigma_noise.shape)==1), "FIRuncFilter: Uncertainty associated with input signal must be a 1D array"
+    elif isinstance(sigma_noise, np.ndarray) and len(sigma_noise.shape) == 1:
         if kind == "diag":
             sigma2 = sigma_noise ** 2
         elif kind == "corr":
@@ -82,7 +81,12 @@ def FIRuncFilter(y, sigma_noise, theta, Utheta=None, shift=0, blow=None, kind="c
             raise ValueError("unknown kind of sigma_noise")
 
     else:
-        raise ValueError("sigma_noise is neither of type float nor numpy.ndarray.")
+        raise ValueError(
+            f"FIRuncFilter: Uncertainty sigma_noise associated "
+            f"with input signal is expected to be either a float or a 1D array but "
+            f"is of shape {sigma_noise.shape}. Please check documentation for input "
+            f"parameters sigma_noise and kind for more information."
+        )
 
 
     if isinstance(blow,np.ndarray):             # calculate low-pass filtered signal and propagate noise

--- a/test/test_propagate_filter.py
+++ b/test/test_propagate_filter.py
@@ -1,49 +1,45 @@
-"""
-Perform test for uncertainty.propagate_filter
-"""
+"""Perform test for uncertainty.propagate_filter"""
 
-import matplotlib.pyplot as plt
 import numpy as np
 
-from PyDynamic.misc.testsignals import rect
-from PyDynamic.misc.tools import make_semiposdef
 from PyDynamic.misc.filterstuff import kaiser_lowpass
 from PyDynamic.misc.noise import power_law_acf, power_law_noise, white_gaussian
-from PyDynamic.uncertainty.propagate_MonteCarlo import MC
+from PyDynamic.misc.testsignals import rect
+from PyDynamic.misc.tools import make_semiposdef
 from PyDynamic.uncertainty.propagate_filter import FIRuncFilter
 
 # parameters of simulated measurement
-Fs = 100e3        # sampling frequency (in Hz)
-Ts = 1 / Fs       # sampling interval length (in s)
+Fs = 100e3  # sampling frequency (in Hz)
+Ts = 1 / Fs  # sampling interval length (in s)
 
 # nominal system parameters
-fcut = 20e3                            # low-pass filter cut-off frequency (6 dB)
-L = 100                                 # filter order
-b1 = kaiser_lowpass(L,   fcut,Fs)[0]
-b2 = kaiser_lowpass(L-20,fcut,Fs)[0]
+fcut = 20e3  # low-pass filter cut-off frequency (6 dB)
+L = 100  # filter order
+b1 = kaiser_lowpass(L, fcut, Fs)[0]
+b2 = kaiser_lowpass(L - 20, fcut, Fs)[0]
 
 # uncertain knowledge: cutoff between 19.5kHz and 20.5kHz
 runs = 1000
-FC = fcut + (2*np.random.rand(runs)-1)*0.5e3
+FC = fcut + (2 * np.random.rand(runs) - 1) * 0.5e3
 
-B = np.zeros((runs,L+1))
-for k in range(runs):        # Monte Carlo for filter coefficients of low-pass filter
-    B[k,:] = kaiser_lowpass(L,FC[k],Fs)[0]
+B = np.zeros((runs, L + 1))
+for k in range(runs):  # Monte Carlo for filter coefficients of low-pass filter
+    B[k, :] = kaiser_lowpass(L, FC[k], Fs)[0]
 
-Ub = make_semiposdef(np.cov(B,rowvar=0))    # covariance matrix of MC result
+Ub = make_semiposdef(np.cov(B, rowvar=0))  # covariance matrix of MC result
 
 # simulate input and output signals
 nTime = 500
-time  = np.arange(nTime)*Ts                     # time values
+time = np.arange(nTime) * Ts  # time values
 
 # different cases
-sigma_noise = 1e-2                              # 1e-5
+sigma_noise = 1e-2  # 1e-5
 
 
 def test_FIRuncFilter_float():
 
     # input signal + run methods
-    x = rect(time,100*Ts,250*Ts,1.0,noise=sigma_noise)
+    x = rect(time, 100 * Ts, 250 * Ts, 1.0, noise=sigma_noise)
 
     # apply uncertain FIR filter (GUM formula)
     for blow in [None, b2]:
@@ -51,34 +47,40 @@ def test_FIRuncFilter_float():
         assert len(y) == len(x)
         assert len(Uy) == len(x)
 
+
 def test_FIRuncFilter_corr():
 
-    # get an instance of noise, the covariance and the covariance-matrix with the specified color
+    # get an instance of noise, the covariance and the covariance-matrix with the
+    # specified color
     color = "white"
     noise = power_law_noise(N=nTime, color_value=color, std=sigma_noise)
     Ux = power_law_acf(nTime, color_value=color, std=sigma_noise)
 
     # input signal
-    x = rect(time,100*Ts,250*Ts,1.0,noise=noise)
+    x = rect(time, 100 * Ts, 250 * Ts, 1.0, noise=noise)
 
     # apply uncertain FIR filter (GUM formula)
     for blow in [None, b2]:
         y, Uy = FIRuncFilter(x, Ux, b1, Ub, blow=blow, kind="corr")
         assert len(y) == len(x)
         assert len(Uy) == len(x)
-    
+
+
 def test_FIRuncFilter_diag():
-    sigma_diag = sigma_noise * ( 1 + np.heaviside(np.arange(len(time)) - len(time)//2,0) )    # std doubles after half of the time
+    sigma_diag = sigma_noise * (
+        1 + np.heaviside(np.arange(len(time)) - len(time) // 2, 0)
+    )  # std doubles after half of the time
     noise = sigma_diag * white_gaussian(len(time))
 
     # input signal + run methods
-    x = rect(time,100*Ts,250*Ts,1.0,noise=noise)
+    x = rect(time, 100 * Ts, 250 * Ts, 1.0, noise=noise)
 
     # apply uncertain FIR filter (GUM formula)
     for blow in [None, b2]:
         y, Uy = FIRuncFilter(x, sigma_diag, b1, Ub, blow=blow, kind="diag")
         assert len(y) == len(x)
         assert len(Uy) == len(x)
+
 
 def test_IIRuncFilter():
     pass

--- a/test/test_propagate_filter.py
+++ b/test/test_propagate_filter.py
@@ -1,6 +1,7 @@
 """Perform test for uncertainty.propagate_filter"""
 
 import numpy as np
+import pytest
 
 from PyDynamic.misc.filterstuff import kaiser_lowpass
 from PyDynamic.misc.noise import power_law_acf, power_law_noise, white_gaussian
@@ -43,7 +44,7 @@ def test_FIRuncFilter_float():
 
     # apply uncertain FIR filter (GUM formula)
     for blow in [None, b2]:
-        y, Uy = FIRuncFilter(x, sigma_noise, b1, Ub, blow=blow, kind="float")
+        y, Uy = FIRuncFilter(x, sigma_noise, b1, Ub, blow=blow)
         assert len(y) == len(x)
         assert len(Uy) == len(x)
 
@@ -80,6 +81,19 @@ def test_FIRuncFilter_diag():
         y, Uy = FIRuncFilter(x, sigma_diag, b1, Ub, blow=blow, kind="diag")
         assert len(y) == len(x)
         assert len(Uy) == len(x)
+
+
+def test_FIRuncFilter_full_cov_matrix():
+    # Setup input signal + run methods
+    x = rect(time, 100 * Ts, 250 * Ts, 1.0, noise=sigma_noise)
+
+    # Setup dummy covariance matrix
+    U_sigma = np.full((len(x), len(x)), sigma_noise)
+
+    # Apply uncertain FIR filter with invalid noise input and check for expected errors.
+    for blow in [None, b2]:
+        with pytest.raises(ValueError):
+            FIRuncFilter(x, U_sigma, b1, Ub, blow=blow)
 
 
 def test_IIRuncFilter():


### PR DESCRIPTION
In `propagate_filter.FIRuncFilter` it is given in the docstring that sigma_noise needs to be either float or a 1D array. However, if this is overlooked and a full covariance matrix used, it causes error messages that are difficult to understand by the user.

This pull request adjusts some code comments and adds an explicit assertion for sigma_noise to be 1D.