### PR TITLE
Fix shifted uncertainty in FIRuncFilter

### DIFF
--- a/PyDynamic/uncertainty/propagate_filter.py
+++ b/PyDynamic/uncertainty/propagate_filter.py
@@ -179,17 +179,17 @@ def FIRuncFilter(y, sigma_noise, theta, Utheta=None, shift=0, blow=None, kind="c
         if isinstance(Utheta, np.ndarray):
             for k in range(len(sigma2)):
                 Ulow = V[k:k+Ntheta,k:k+Ntheta]
-                UncCov[k] = np.squeeze(theta.T.dot(Ulow.dot(theta)) + np.abs(np.trace(Ulow.dot(Utheta))))  # static part of uncertainty
+                UncCov[k] = np.squeeze(np.flip(theta).T.dot(Ulow.dot(np.flip(theta))) + np.abs(np.trace(Ulow.dot(np.flip(Utheta)))))  # static part of uncertainty
         else:
             for k in range(len(sigma2)):
                 Ulow = V[k:k+Ntheta,k:k+Ntheta]
-                UncCov[k] = np.squeeze(theta.T.dot(Ulow.dot(theta)))  # static part of uncertainty
+                UncCov[k] = np.squeeze(np.flip(theta).T.dot(Ulow.dot(np.flip(theta))))  # static part of uncertainty
 
     else:
         if isinstance(Utheta, np.ndarray):
-            UncCov = theta.T.dot(Ulow.dot(theta)) + np.abs(np.trace(Ulow.dot(Utheta)))      # static part of uncertainty
+            UncCov = np.flip(theta).T.dot(Ulow.dot(np.flip(theta))) + np.abs(np.trace(Ulow.dot(np.flip(Utheta))))      # static part of uncertainty
         else:
-            UncCov = theta.T.dot(Ulow.dot(theta))     # static part of uncertainty
+            UncCov = np.flip(theta).T.dot(Ulow.dot(np.flip(theta)))     # static part of uncertainty
 
     if isinstance(Utheta, np.ndarray):
         unc = np.empty_like(y)
@@ -199,8 +199,8 @@ def FIRuncFilter(y, sigma_noise, theta, Utheta=None, shift=0, blow=None, kind="c
         
         for m in range(len(xlow)):
             # extract necessary part from input signal
-            XL = xlow_extended[m : m + Ntheta, np.newaxis][::-1]  
-            unc[m] = XL.T.dot(Utheta.dot(XL))  # apply formula from paper
+            XL = xlow_extended[m : m + Ntheta, np.newaxis]
+            unc[m] = XL.T.dot(np.flip(Utheta).dot(XL))  # apply formula from paper
     else:
         unc = np.zeros_like(y)
     

--- a/PyDynamic/uncertainty/propagate_filter.py
+++ b/PyDynamic/uncertainty/propagate_filter.py
@@ -170,6 +170,13 @@ def FIRuncFilter(y, sigma_noise, theta, Utheta=None, shift=0, blow=None, kind="c
     if len(theta.shape) == 1:
         theta = theta[:, np.newaxis]
 
+    # NOTE: In the code below whereever `theta` or `Utheta` get used, they need to be flipped. 
+    #       This is necessary to take the time-order of both variables into account. (Which is descending
+    #       for `theta` and `Utheta` but ascending for `Ulow`.)
+    #       
+    #       Further details and illustrations showing the effect of not-flipping
+    #       can be found at https://github.com/PTB-PSt1/PyDynamic/issues/183
+
     # handle diag-case, where Ulow needs to be sliced from V
     if kind == "diag":
         # UncCov needs to be calculated inside in its own for-loop

--- a/test/test_propagate_filter.py
+++ b/test/test_propagate_filter.py
@@ -46,7 +46,7 @@ def valid_signals():
     valid_signals = [
         {"y": signal, "sigma_noise": np.random.randn(), "kind": "float"},
         {"y": signal, "sigma_noise": random_nonnegative_array(N), "kind": "diag"},
-        {"y": signal, "sigma_noise": random_array(N // 2), "kind": "corr"},
+        {"y": signal, "sigma_noise": random_nonnegative_array(N // 2), "kind": "corr"},
     ]
 
     return valid_signals

--- a/test/test_propagate_filter.py
+++ b/test/test_propagate_filter.py
@@ -2,10 +2,12 @@
 import itertools
 
 import numpy as np
+import scipy
 import pytest
 
-from PyDynamic.misc.tools import make_semiposdef
+from PyDynamic.misc.tools import make_semiposdef, trimOrPad
 from PyDynamic.uncertainty.propagate_filter import FIRuncFilter
+from PyDynamic.uncertainty.propagate_MonteCarlo import MC
 
 
 def random_array(length):
@@ -30,6 +32,7 @@ def valid_filters():
 
     valid_filters = [
         {"theta": theta, "Utheta": None},
+        {"theta": theta, "Utheta": np.zeros((N, N))},
         {"theta": theta, "Utheta": random_semiposdef_matrix(N)},
     ]
 
@@ -128,6 +131,43 @@ def test_FIRuncFilter_equality(equal_filters, equal_signals):
 
     for a, b in itertools.combinations(all_uy, 2):
         assert np.allclose(a, b)
+
+
+@pytest.mark.parametrize("filters", valid_filters())
+@pytest.mark.parametrize("signals", valid_signals()[:2])  # exclude kind="corr"
+@pytest.mark.parametrize("lowpasses", valid_lows())
+def test_FIRuncFilter_MC_uncertainty_comparison(filters, signals, lowpasses):
+    # Check output for thinkable permutations of input parameters against a Monte Carlo approach.
+
+    # adjust input to match conventions of MC
+    x = signals["y"]
+    ux = signals["sigma_noise"]
+
+    b = filters["theta"]
+    a = [1.0]
+    if isinstance(filters["Utheta"], np.ndarray):
+        Uab = filters["Utheta"]
+    else:
+        Uab = np.zeros((len(b), len(b)))  # MC-method cant deal with Utheta = None
+
+    blow = lowpasses["blow"]
+
+    # apply filter
+    y_fir, uy_fir = FIRuncFilter(**filters, **signals, **lowpasses)
+    y_mc, uy_mc = MC(x, ux, b, a, Uab, blow=blow, runs=2000)
+    uy_mc = np.sqrt(np.diag(uy_mc))
+
+    # approximative comparison after swing-in of MC-result
+
+    # HACK: for visualization during testing
+    # import matplotlib.pyplot as plt
+    # plt.plot(uy_fir, label="fir")
+    # plt.plot(uy_mc, label="mc")
+    # plt.legend()
+    # plt.show()
+    # /HACK
+
+    assert np.allclose(uy_fir[len(b) :], uy_mc[len(b) :], atol=1e-1, rtol=1e-1)
 
 
 def test_IIRuncFilter():

--- a/test/test_propagate_filter.py
+++ b/test/test_propagate_filter.py
@@ -135,7 +135,7 @@ def test_FIRuncFilter_equality(equal_filters, equal_signals):
 
 # in the following test, we exclude the case of a valid signal with uncertainty given as
 # the right-sided auto-covariance (acf). This is done, because we currently do not ensure, that
-# the random-drawn acf generates a positive-semidefinite Toeplitz-matrix. Therefore we cannot 
+# the random-drawn acf generates a positive-semidefinite Toeplitz-matrix. Therefore we cannot
 # construct a valid and equivalent input for the Monte-Carlo method in that case.
 @pytest.mark.parametrize("filters", valid_filters())
 @pytest.mark.parametrize("signals", valid_signals()[:2])  # exclude kind="corr"
@@ -155,26 +155,36 @@ def test_FIRuncFilter_MC_uncertainty_comparison(filters, signals, lowpasses):
     a = [1.0]
     if isinstance(filters["Utheta"], np.ndarray):
         Uab = filters["Utheta"]
-    else:  # Utheta == None 
+    else:  # Utheta == None
         Uab = np.zeros((len(b), len(b)))  # MC-method cant deal with Utheta = None
 
     blow = lowpasses["blow"]
+    if isinstance(blow, np.ndarray):
+        n_blow = len(blow)
+    else:
+        n_blow = 0
 
     ## run FIR with MC and extract diagonal of returned covariance
     y_mc, uy_mc = MC(x, ux, b, a, Uab, blow=blow, runs=2000)
     uy_mc = np.sqrt(np.diag(uy_mc))
 
-    
     # HACK: for visualization during debugging
     # import matplotlib.pyplot as plt
     # plt.plot(uy_fir, label="fir")
     # plt.plot(uy_mc, label="mc")
+    # plt.title("filter: {0}, signal: {1}".format(len(b), len(x)))
     # plt.legend()
     # plt.show()
     # /HACK
 
     # approximative comparison after swing-in of MC-result
-    assert np.allclose(uy_fir[len(b) :], uy_mc[len(b) :], atol=1e-1, rtol=1e-1)
+    # (which is after the combined length of blow and b)
+    assert np.allclose(
+        uy_fir[len(b) + n_blow :],
+        uy_mc[len(b) + n_blow :],
+        atol=1e-1,
+        rtol=1e-1,
+    )
 
 
 def test_IIRuncFilter():


### PR DESCRIPTION
As mentioned in #183 , introduce a fix for the encountered bug and introduce tests to validate the `FIRuncFilter` method against the outcome of a Monte Carlo simulation. 