### PR TITLE
Introduce throwing an error in case of invalid input in filterstuff.isstable

### DIFF
--- a/PyDynamic/misc/filterstuff.py
+++ b/PyDynamic/misc/filterstuff.py
@@ -170,6 +170,10 @@ def isstable(b, a, ftype="digital"):
         return not np.any(np.abs(v) > 1.0)
     elif ftype == "analog":
         return not np.any(np.real(v) < 0)
+    else:
+        raise ValueError(f"isstable: filter type 'ftype={ftype}'unknown. Please "
+                         f"check documentation and choose a valid assignment for "
+                         f"'ftype' or leave out to fallback to default.")
 
 
 def savitzky_golay(y, window_size, order, deriv=0, delta=1.0):

--- a/test/test_isstable.py
+++ b/test/test_isstable.py
@@ -2,6 +2,7 @@
 """ Perform tests on *misc.filterstuff.isstable*."""
 
 import numpy as np
+import pytest
 
 from PyDynamic.misc.filterstuff import isstable
 
@@ -18,3 +19,11 @@ def test_not_stable():
     b = np.array([1, 1])
     a = np.array([-0.999999999, 1])
     assert not isstable(b, a)
+
+
+def test_error_isstable():
+    """Test if isstable raises an error for invalid ftype"""
+    b = np.array([1, 1])
+    a = np.array([-0.999999999, 1])
+    with pytest.raises(ValueError):
+        isstable(b, a, ftype="something_invalid")


### PR DESCRIPTION
The function `isstable()` returns an boolean to tell, if the filter designed from the input coefficients is stable or not. In case an invalid `ftype` is provided, the method returned None, which in many cases would be confused with False. We raise an exception instead to avoid this confusion and save debugging time.