### PR TITLE
Introduce testing against conda interpreter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ version: 2.1
 executors:
   # Define a parameterized executor which accepts two parameters to choose the python
   # version which will be used for the docker image and the tox actions.
-  tester:
+  venv_tester:
     working_directory: ~/repo
     parameters:
       tag:
@@ -15,6 +15,10 @@ executors:
         default: "3.8"
     docker:
       - image: circleci/python:<< parameters.tag >>
+  conda_tester:
+    working_directory: ~/repo
+    docker:
+      - image: cimg/base
   # Define the executor for the Python semantic release.
   publisher:
     working_directory: ~/repo
@@ -32,12 +36,8 @@ executors:
 
 commands:
   # Reusable command to prepare the environment for testing.
-  create_folders_and_venv:
-    description: "Prepare everything."
-    parameters:
-      pyenv:
-        type: string
-        default: "py38"
+  create_folders:
+    description: "Checkout code and prepare test results location."
     steps:
     # Checkout code.
     - checkout
@@ -47,6 +47,14 @@ commands:
         command: |
           mkdir test-results
 
+  # Reusable command to prepare the environment for testing.
+  create_venv:
+    description: "Prepare virtual environment."
+    parameters:
+      pyenv:
+        type: string
+        default: "py38"
+    steps:
     # Create PyDynamic virtual environment.
     - run:
         name: Create virtual environment
@@ -56,7 +64,7 @@ commands:
           pip install --upgrade pip setuptools
 
   # Reusable command to install production dependencies.
-  install__production_deps:
+  install_production_deps:
     description: "Install production dependencies."
     parameters:
       pyenv:
@@ -72,7 +80,7 @@ commands:
           pip install -r requirements/requirements-<< parameters.pyenv >>.txt
 
   # Reusable command to install development dependencies.
-  install__development_deps:
+  install_development_deps:
     description: "Install development dependencies."
     parameters:
       pyenv:
@@ -135,6 +143,7 @@ workflows:
           name: "test_python3.8"
           tag: "3.8"
           pyenv: "py38"
+      - test_conda3.8
       - preview_release:
           # Test the 'release' job to avoid trouble when Pull Requests get merged and
           # to preview publishing actions and the new changelog.
@@ -142,6 +151,7 @@ workflows:
             - test_python3.6
             - test_python3.7
             - test_python3.8
+            - test_conda3.8
       - confirm_previewed_release_actions:
           # This job allows for checking that the release we will create in the
           # next step actually is the desired release, by observing the result of
@@ -194,16 +204,17 @@ jobs:
 
     # Specify the executor and hand over the docker image tag parameter.
     executor:
-      name: tester
+      name: venv_tester
       tag: << parameters.tag >>
 
     # Specify the steps to execute during this test jobs.
     steps:
-      - create_folders_and_venv:
+      - create_folders
+      - create_venv:
           pyenv: << parameters.pyenv >>
-      - install__production_deps:
+      - install_production_deps:
           pyenv: << parameters.pyenv >>
-      - install__development_deps:
+      - install_development_deps:
           pyenv: << parameters.pyenv >>
       - tox:
           pyenv: << parameters.pyenv >>
@@ -218,18 +229,85 @@ jobs:
                 name: Upload coverage report
                 command: |
                   source << parameters.pyenv >>/bin/activate
-                  bash <(curl -s https://codecov.io/bash)
+                curl -s https://codecov.io/bash > codecov;
+                VERSION=$(grep -o 'VERSION=\"[0-9\.]*\"' codecov | cut -d'"' -f2);
+                for i in 1 256 512
+                do
+                  shasum -a $i -c --ignore-missing <(curl -s "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM") ||
+                  shasum -a $i -c <(curl -s "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM")
+                done
+                chmod u+x codecov
+                ./codecov
+
+  # Define one 'test' job to run the test suite against the
+  # installed dependencies from the environment.yml.
+  test_conda3.8:
+
+    executor: conda_tester
+
+    steps:
+      - create_folders
+      - run:
+          name: Install Miniconda
+          command: |
+            wget "https://repo.anaconda.com/miniconda/\
+            Miniconda3-latest-Linux-x86_64.sh" -O $HOME/miniconda.sh
+            mkdir -p $HOME/.conda
+            bash $HOME/miniconda.sh -b -p /home/circleci/conda
+            source $HOME/conda/etc/profile.d/conda.sh
+            hash -r
+            conda config --set always_yes yes --set changeps1 no
+            conda update -q conda
+            echo 'export PATH=$HOME/conda/bin:$PATH' >> $BASH_ENV
+
+      # Download and cache dependencies.
+      - restore_cache:
+          keys:
+            # Specify the unique identifier for the cache.
+            - v1-conda-dependencies-{{ checksum "requirements/environment.yml" }}-{{ checksum "requirements/requirements.txt" }}-{{ checksum "requirements/dev-requirements.txt" }}
+            # Fallback to using the latest cache if no exact match is found.
+            - v1-conda-dependencies-
+
+      # Create environment and install extra_requires dependencies manually.
+      - run:
+          name: Create or update environment
+          command: |
+            if [ -d "$HOME/conda/envs/" ]; then
+                conda env update --prune --file requirements/environment.yml
+            else
+                conda env create -f requirements/environment.yml
+            fi
+            source $HOME/conda/etc/profile.d/conda.sh
+            conda activate PyDynamic_conda_env
+            pip install -r requirements/dev-requirements.txt
+
+      - save_cache:
+          paths:
+            - /home/circleci/conda/envs/
+          key: >-
+            v1-conda-dependencies-{{ checksum "requirements/environment.yml" }}-{{ checksum "requirements/requirements.txt" }}-{{ checksum "requirements/dev-requirements.txt" }}
+
+      # Run tests! We use pytest's test-runner.
+      - run:
+          name: Run tests
+          command: |
+            source $HOME/conda/etc/profile.d/conda.sh
+            conda activate PyDynamic_conda_env
+            tox | tee --append test-results/pytest.log
+
+      - store_test_artifacts_and_results
 
   release:
     executor:
       name: publisher
 
     steps:
-      - create_folders_and_venv:
+      - create_folders
+      - create_venv:
           pyenv: ${PYENV}
-      - install__production_deps:
+      - install_production_deps:
           pyenv: ${PYENV}
-      - install__development_deps:
+      - install_development_deps:
           pyenv: ${PYENV}
 
       # Publish it, if there is anything to publish!
@@ -246,7 +324,8 @@ jobs:
       name: publisher
 
     steps:
-      - create_folders_and_venv:
+      - create_folders
+      - create_venv:
           pyenv: ${PYENV}
       - install__production_deps:
           pyenv: ${PYENV}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,7 +295,8 @@ jobs:
             conda activate PyDynamic_conda_env
             tox | tee --append test-results/pytest.log
 
-      - store_results
+      - store_results:
+          pyenv: "py38"
 
   release:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,7 +295,7 @@ jobs:
             conda activate PyDynamic_conda_env
             tox | tee --append test-results/pytest.log
 
-      - store_test_artifacts_and_results
+      - store_results
 
   release:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -323,9 +323,9 @@ jobs:
       - create_folders
       - create_venv:
           pyenv: ${PYENV}
-      - install__production_deps:
+      - install_production_deps:
           pyenv: ${PYENV}
-      - install__development_deps:
+      - install_development_deps:
           pyenv: ${PYENV}
 
       # Fake publish, just to make sure everything works after merging a PR and

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,27 +131,27 @@ workflows:
     jobs:
       # Create 'test' job to test and install PyDynamic for every commit.
       - test:
-          name: "test_python3.6"
+          name: "test_python_py36"
           tag: "3.6"
           pyenv: "py36"
       - test:
-          name: "test_python3.7"
+          name: "test_python_py37"
           tag: "3.7"
           pyenv: "py37"
           send_cov: true
       - test:
-          name: "test_python3.8"
+          name: "test_python_py38"
           tag: "3.8"
           pyenv: "py38"
-      - test_conda3.8
+      - test_conda_py38
       - preview_release:
           # Test the 'release' job to avoid trouble when Pull Requests get merged and
           # to preview publishing actions and the new changelog.
           requires:
-            - test_python3.6
-            - test_python3.7
-            - test_python3.8
-            - test_conda3.8
+            - test_python_py36
+            - test_python_py37
+            - test_python_py38
+            - test_conda_py38
       - confirm_previewed_release_actions:
           # This job allows for checking that the release we will create in the
           # next step actually is the desired release, by observing the result of
@@ -241,7 +241,7 @@ jobs:
 
   # Define one 'test' job to run the test suite against the
   # installed dependencies from the environment.yml.
-  test_conda3.8:
+  test_conda_py38:
 
     executor: conda_tester
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,15 +229,15 @@ jobs:
                 name: Upload coverage report
                 command: |
                   source << parameters.pyenv >>/bin/activate
-                curl -s https://codecov.io/bash > codecov;
-                VERSION=$(grep -o 'VERSION=\"[0-9\.]*\"' codecov | cut -d'"' -f2);
-                for i in 1 256 512
-                do
-                  shasum -a $i -c --ignore-missing <(curl -s "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM") ||
-                  shasum -a $i -c <(curl -s "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM")
-                done
-                chmod u+x codecov
-                ./codecov
+                  curl -s https://codecov.io/bash > codecov;
+                  VERSION=$(grep -o 'VERSION=\"[0-9\.]*\"' codecov | cut -d'"' -f2);
+                  for i in 1 256 512
+                  do
+                    shasum -a $i -c --ignore-missing <(curl -s "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM") ||
+                    shasum -a $i -c <(curl -s "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM")
+                  done
+                  chmod u+x codecov
+                  ./codecov
 
   # Define one 'test' job to run the test suite against the
   # installed dependencies from the environment.yml.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ executors:
   conda_tester:
     working_directory: ~/repo
     docker:
-      - image: cimg/base
+      - image: cimg/base:2021.04
   # Define the executor for the Python semantic release.
   publisher:
     working_directory: ~/repo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,9 +113,6 @@ commands:
   # Reusable command to store the previously generated test results.
   store_results:
     description: "Store test results and artifacts."
-    parameters:
-      pyenv:
-        type: string
     steps:
     # Store test results.
     - store_artifacts:
@@ -218,8 +215,7 @@ jobs:
           pyenv: << parameters.pyenv >>
       - tox:
           pyenv: << parameters.pyenv >>
-      - store_results:
-          pyenv: << parameters.pyenv >>
+      - store_results
 
       # Upload coverage report if the according parameter is set to `true`.
       - when:
@@ -295,8 +291,7 @@ jobs:
             conda activate PyDynamic_conda_env
             tox | tee --append test-results/pytest.log
 
-      - store_results:
-          pyenv: "py38"
+      - store_results
 
   release:
     executor:

--- a/requirements/environment.yml
+++ b/requirements/environment.yml
@@ -3,6 +3,7 @@ channels:
     - defaults
 dependencies:
     - python = 3.8
+    - pip
     # pip dependencies have to be provided in `requirements.txt` syntax
     - pip:
         - -r requirements.txt


### PR DESCRIPTION
In Met4FoF we discovered a problem with the Anaconda installation during our the runs of our CI pipeline. Since we provide an _environment.yml_ for PyDynamic, we should check for proper installation and test execution on Anaconda as well. This is introduced in this PR.

Additionally we introduce a checksum check for the Codecov Bash Uploader being part of one of our test runs. Codecov calculates the code coverage for our tests and uses a bash script to do the uploading. We download it from their servers during our pipeline runs and execute it in our CI environment. In March 2021 they got hacked and a malicious script was put into place, which had access to all environment variables, access tokens and such things, which are accessible in the respective pipeline jobs. To avoid this in the future, we check against officially provided hash sums, such that an attacker would need to gain access to the publishing location of the hash sums and the script location, which is much more unlikely.